### PR TITLE
iOS: Show a fully functional numeric keyboard ( input[type=number] )

### DIFF
--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -56,8 +56,8 @@ export default class NumberController extends Controller {
 	_initInput() {
 
 		this.$input = document.createElement( 'input' );
-		this.$input.setAttribute( 'type', 'text' );
-		this.$input.setAttribute( 'inputmode', 'decimal' );
+		this.$input.setAttribute( 'type', 'number' );
+		this.$input.setAttribute( 'step', 'any' );
 		this.$input.setAttribute( 'aria-labelledby', this.$name.id );
 
 		this.$widget.appendChild( this.$input );

--- a/style/inputs.scss
+++ b/style/inputs.scss
@@ -23,11 +23,24 @@
 		}
 	}
 
-	input[type='text'] {
+	input[type='text'],
+	input[type='number'] {
 		padding: var(--widget-padding);
 		&:focus {
 			background: var(--focus-color);
 		}
+	}
+
+	// Hide number spinners
+
+	input::-webkit-outer-spin-button,
+	input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+	
+	input[type='number'] {
+		-moz-appearance: textfield;
 	}
 
 	input[type='checkbox'] {
@@ -49,7 +62,6 @@
 				box-shadow: inset 0 0 0 1px var(--focus-color);
 			}
 		}
-
 	}
 
 	button {


### PR DESCRIPTION
I was hoping to avoid `<input type="number">` for `NumberController`. We're not using any of its stepping / clamping, the alt messages it shows on invalid entries are distracting, and there's a fair bit of CSS required to get rid of the native styles.

Still, it's important that mobile users get a numeric keyboard by default when focusing a number field. Up until now I had hoped to accomplish that with `<input type="text" inputmode="decimal">`. That's enough on Android, but naturally iOS must be difficult.

**The iOS keyboard doesn't show a negative symbol with `inputmode="decimal"`**. Strangely, they aren't required to. From the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) on inputmode decimal:

> Fractional numeric input keyboard containing the digits and decimal separator for the user's locale (typically <kbd>.</kbd> or <kbd>,</kbd>). **Devices may or may not show a minus key (<kbd>-</kbd>).**

**The only way to default to a fully functional numeric keyboard on iOS is with `<input type="number">`**. I'm not excited about changing something foundational like this, but so far I haven't been able to distinguish between the two input types. I wish it wasn't necessary, but I think the change is justified: iPhones are popular.