### PR TITLE
0.14.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.14.0
+
+- Added `gui.onFinishChange` for symmetry with `gui.onChange`.
+
 # 0.13.0
 
 28.56kb, 8.24kb gzipped

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,9 @@
 # 0.14.0
 
+29.04kb, 8.31kb gzipped
+
 - Added `gui.onFinishChange` for symmetry with `gui.onChange`.
-- Fixed a bug that stopped iOS users from typing negative numbers. ([Note](#))
+- Fixed a bug that stopped iOS users from typing negative numbers. ([Note](https://github.com/georgealways/lil-gui/pull/16))
 - Minor CSS fixes.
 
 # 0.13.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 29.04kb, 8.31kb gzipped
 
 - Added `gui.onFinishChange` for symmetry with `gui.onChange`.
+- Added a `d.ts` file for TypeScript users.
 - Fixed a bug that stopped iOS users from typing negative numbers. ([Note](https://github.com/georgealways/lil-gui/pull/16))
 - Minor CSS fixes.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # 0.14.0
 
 - Added `gui.onFinishChange` for symmetry with `gui.onChange`.
+- Fixed a bug that stopped iOS users from typing negative numbers. ([Note](#))
+- Minor CSS fixes.
 
 # 0.13.0
 

--- a/Guide.md
+++ b/Guide.md
@@ -202,6 +202,8 @@ gui.onChange( event => {
 `GUI.onChange` events bubble upward. A handler applied to the root GUI will fire after every change. 
 Handlers applied to folders will only be called after changes to that folder or its descendents.
 
+`GUI.onFinishChange` works just like `GUI.onChange`, but it only fires at the end of change events.
+
 ### Listening and Updating
 
 If a value controlled by the GUI is changed in code anywhere outside of the GUI, the new value won't

--- a/Guide.md
+++ b/Guide.md
@@ -23,14 +23,14 @@ For quick sketches, you can import lil-gui directly from a CDN.
 
 ```html
 <script type="module">
-import GUI from '//cdn.jsdelivr.net/npm/lil-gui@VERSION/+esm';
+import GUI from 'https://cdn.jsdelivr.net/npm/lil-gui@VERSION/+esm';
 </script>
 ```
 
 The library is also available in UMD format under the namespace `lil`.
 
 ```html
-<script src="//cdn.jsdelivr.net/npm/lil-gui@VERSION"></script>
+<script src="https://cdn.jsdelivr.net/npm/lil-gui@VERSION"></script>
 <script>
 var GUI = lil.GUI;
 </script>

--- a/TODO
+++ b/TODO
@@ -6,6 +6,9 @@
 	only way to default to a keyboard with numbers, decimals and a negative sign
 	on ios is with input[type=number]. i hate unstyling that thing
 
+[ ] -webkit-tap-highlight is still on boolean and option
+	but there's no :active style on either without it
+
 0.13
 
 [-] test color malform/edge cases

--- a/TODO
+++ b/TODO
@@ -6,10 +6,14 @@
 	only way to default to a keyboard with numbers, decimals and a negative sign
 	on ios is with input[type=number]. i hate unstyling that thing
 
-[ ] -webkit-tap-highlight is still on boolean and option
-	but there's no :active style on either without it
+[-] -webkit-tap-highlight is still on boolean and option
+	but there's no :active style on either without it (branch: mobileactivestates)
 
-[ ] move --string-color and --number-color to inputs.scss
+[ ] button text-transform: none
+	this was there to compensate for a very broad css selector in the three.js 
+	examples while developing, shouldn't be there
+
+[-] move --string-color and --number-color to inputs.scss
 
 0.13
 

--- a/TODO
+++ b/TODO
@@ -1,6 +1,6 @@
 0.14
 
-[ ] GUI.onFinishChange (branch: undo)
+[x] GUI.onFinishChange (branch: undo)
 [ ] ios negative numbers (branch: typenumber)
 	the spec for inputmode=decimal doesn't mandate a negative sign
 	only way to default to a keyboard with numbers, decimals and a negative sign

--- a/TODO
+++ b/TODO
@@ -9,9 +9,10 @@
 [-] -webkit-tap-highlight is still on boolean and option
 	but there's no :active style on either without it (branch: mobileactivestates)
 
-[ ] button text-transform: none
+[-] button text-transform: none
 	this was there to compensate for a very broad css selector in the three.js 
-	examples while developing, shouldn't be there
+	examples while developing, shouldn't be there.
+	well, in truth there's a bunch of 'resets' in the .lil-gui { selector too
 
 [-] move --string-color and --number-color to inputs.scss
 

--- a/TODO
+++ b/TODO
@@ -1,13 +1,15 @@
 0.14
 
 [x] GUI.onFinishChange (branch: undo)
-[ ] ios negative numbers (branch: typenumber)
+[x] ios negative numbers (branch: typenumber)
 	the spec for inputmode=decimal doesn't mandate a negative sign
 	only way to default to a keyboard with numbers, decimals and a negative sign
 	on ios is with input[type=number]. i hate unstyling that thing
 
 [ ] -webkit-tap-highlight is still on boolean and option
 	but there's no :active style on either without it
+
+[ ] move --string-color and --number-color to inputs.scss
 
 0.13
 

--- a/examples/kitchen-sink/index.html
+++ b/examples/kitchen-sink/index.html
@@ -308,6 +308,10 @@
 
 			gui.addColor( { Color: 0xaa00ff }, 'Color' ).onChange( change ).onFinishChange( finishChange );
 
+			gui.onFinishChange( e => {
+				console.log( 'gui.onFinishChange', e );
+			} );
+
 		} );
 
 		make( { title: 'Customization' }, gui => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "jsdoc-api": "^5.0.2",
         "markdown-it": "^9.1.0",
         "onchange": "^6.0.0",
+        "rimraf": "^3.0.2",
         "rollup": "^1.17.0",
         "sass": "^1.22.10",
         "terser": "^4.3.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lil-gui",
-  "version": "0.13.0",
+  "version": "0.14.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lil-gui",
-      "version": "0.13.0",
+      "version": "0.14.0-dev",
       "license": "MIT",
       "devDependencies": {
         "browser-sync": "^2.27.7",
@@ -22,6 +22,7 @@
         "rollup": "^1.17.0",
         "sass": "^1.22.10",
         "terser": "^4.3.8",
+        "typescript": "^4.5.2",
         "webfont": "^11.2.26"
       }
     },
@@ -4547,6 +4548,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
@@ -8568,6 +8582,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "node -r esm tests/utils/runner.js",
     "api": "node -r esm scripts/api.js --write",
     "homepage": "node -r esm scripts/homepage.js",
-    "server": "browser-sync start -s -f '$npm_package_main' 'index.html' 'examples' --no-open --no-notify --no-ui --no-ghost-mode --no-inject-changes",
+    "server": "browser-sync start -s -f 'dist' 'index.html' 'examples' --no-open --no-notify --no-ui --no-ghost-mode --no-inject-changes",
     "preversion": "npm run build && npm test",
     "prepublishOnly": "npm run build && npm test",
     "dev": "npm run build:all && node -r esm scripts/dev.js"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "types": "tsc dist/lil-gui.esm.js --declaration --allowJs --emitDeclarationOnly --outDir dist",
     "homepage": "node -r esm scripts/homepage.js",
     "server": "browser-sync start -s -f 'dist' 'index.html' 'examples' --no-open --no-notify --no-ui --no-ghost-mode --no-inject-changes",
+    "clean": "rimraf -rf dist/*",
     "preversion": "npm run build && npm test",
     "prepublishOnly": "npm run clean && npm run build && npm run types && npm test",
     "dev": "npm run build:all && node -r esm scripts/dev.js"
@@ -45,6 +46,7 @@
     "jsdoc-api": "^5.0.2",
     "markdown-it": "^9.1.0",
     "onchange": "^6.0.0",
+    "rimraf": "^3.0.2",
     "rollup": "^1.17.0",
     "sass": "^1.22.10",
     "terser": "^4.3.8",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "homepage": "https://lil-gui.georgealways.com",
   "module": "dist/lil-gui.esm.js",
   "main": "dist/lil-gui.umd.js",
+  "types": "dist/lil-gui.esm.d.ts",
   "config": {
     "style": "dist/lil-gui.css",
     "styleMin": "dist/lil-gui.min.css"
@@ -22,10 +23,11 @@
     "icons": "node -r esm scripts/icons.js",
     "test": "node -r esm tests/utils/runner.js",
     "api": "node -r esm scripts/api.js --write",
+    "types": "tsc dist/lil-gui.esm.js --declaration --allowJs --emitDeclarationOnly --outDir dist",
     "homepage": "node -r esm scripts/homepage.js",
     "server": "browser-sync start -s -f 'dist' 'index.html' 'examples' --no-open --no-notify --no-ui --no-ghost-mode --no-inject-changes",
     "preversion": "npm run build && npm test",
-    "prepublishOnly": "npm run build && npm test",
+    "prepublishOnly": "npm run clean && npm run build && npm run types && npm test",
     "dev": "npm run build:all && node -r esm scripts/dev.js"
   },
   "files": [
@@ -46,6 +48,7 @@
     "rollup": "^1.17.0",
     "sass": "^1.22.10",
     "terser": "^4.3.8",
+    "typescript": "^4.5.2",
     "webfont": "^11.2.26"
   },
   "eslintIgnore": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "npm run icons && npm run sass && npm run sass:min && npm run rollup",
     "build:all": "npm run build && npm run api && npm run homepage",
-    "sass": "sass style/index.scss dist/lil-gui.css --no-source-map --no-charset",
+    "sass": "sass style/index.scss dist/lil-gui.css --no-charset --no-source-map",
     "sass:min": "sass style/index.scss dist/lil-gui.min.css --no-charset --no-source-map --style=compressed",
     "rollup": "rollup -c",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "build": "npm run icons && npm run sass && npm run sass:min && npm run rollup",
     "build:all": "npm run build && npm run api && npm run homepage",
-    "sass": "sass style/index.scss $npm_package_config_style --no-source-map --no-charset",
-    "sass:min": "sass style/index.scss $npm_package_config_styleMin --no-charset --no-source-map --style=compressed",
+    "sass": "sass style/index.scss dist/lil-gui.css --no-source-map --no-charset",
+    "sass:min": "sass style/index.scss dist/lil-gui.min.css --no-charset --no-source-map --style=compressed",
     "rollup": "rollup -c",
     "lint": "eslint .",
     "icons": "node -r esm scripts/icons.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lil-gui",
-  "version": "0.13.0",
+  "version": "0.14.0-dev",
   "author": {
     "name": "George Michael Brower"
   },

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -254,7 +254,7 @@ function paramsToSignature( params ) {
 		.map( singleParamToSignature )
 		.join( ', ' );
 
-	return `(&nbsp;${paramList}&nbsp;)`;
+	return `( ${paramList} )`;
 
 }
 

--- a/scripts/homepage.hbs.html
+++ b/scripts/homepage.hbs.html
@@ -972,7 +972,7 @@
 				{{{ readme }}}
 
 				<a href="{{ builds.module }}">Built Source</a> • 
-				<a href="{{ builds.moduleMin }}">Minified</a> = <strong>{{ sizeMin }}kb</strong>, {{ sizeGzip }}kb gzipped
+				<a href="{{ builds.moduleMin }}">Minified</a> = {{ sizeMin }}kb, <strong>{{ sizeGzip }}kb</strong> gzipped
 				
 			</section>
 

--- a/scripts/homepage.hbs.html
+++ b/scripts/homepage.hbs.html
@@ -987,7 +987,7 @@
 							Hot Swap</a> - Replaces dat.gui across all three.js example pages. Except for a
 						few, this was done just by replacing the import URL.</li>
 					<li><a href="https://lil-gui-pixi.georgealways.com/tools/demo/">PixiJS Filters Demo Hot Swap</a> -
-						Replacing a very long dat.gui.</li>
+						Replaces a very long dat.gui.</li>
 				</ul>
 			</section>
 

--- a/scripts/homepage.hbs.html
+++ b/scripts/homepage.hbs.html
@@ -22,10 +22,10 @@
 			--link: #005dcc;
 			--pre-code: #d1d0cc;
 			--inline-code: #926501;
-			--code-number: #73c6ee;
-			--code-string: #a3c04a;
-			--code-literal: #db80c7;
-			--code-special: #6ed3d3;
+			--code-number: #6cb2e3;
+			--code-string: #a6bf5c;
+			--code-literal: #bd75cb;
+			--code-special: #80d3c7;
 			--code-comment: #84858a;
 			--pre-background: #372d39;
 			--toc-width: 210px;

--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -47,8 +47,8 @@ guide = guide.replace( /^## ([\s\S]*?)$/gm, function( _, heading ) {
 
 } );
 
-// include version in CDN examples, bad form to use bare/latest
-guide = guide.replace( /@VERSION/g, '@' + pkg.version );
+// include major & minor version in CDN examples, bad form to use bare/latest
+guide = guide.replace( /@VERSION/g, '@' + pkg.version.substring( 0, pkg.version.lastIndexOf( '.' ) ) );
 
 // API.md
 // -----------------------------------------------------------------------------

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -166,6 +166,8 @@ export default class Controller {
 	 */
 	_callOnFinishChange() {
 
+		this.parent._callOnFinishChange( this );
+
 		if ( this._changed && this._onFinishChange !== undefined ) {
 			this._onFinishChange.call( this, this.getValue() );
 		}

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -166,10 +166,14 @@ export default class Controller {
 	 */
 	_callOnFinishChange() {
 
-		this.parent._callOnFinishChange( this );
+		if ( this._changed ) {
 
-		if ( this._changed && this._onFinishChange !== undefined ) {
-			this._onFinishChange.call( this, this.getValue() );
+			this.parent._callOnFinishChange( this );
+
+			if ( this._onFinishChange !== undefined ) {
+				this._onFinishChange.call( this, this.getValue() );
+			}
+
 		}
 
 		this._changed = false;

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -489,6 +489,39 @@ export default class GUI {
 	}
 
 	/**
+	 * Pass a function to be called whenever a controller in this GUI has finished changing.
+	 * @param {function({object:object, property:string, value:any, controller:Controller})} callback
+	 * @returns {this}
+	 * @example
+	 * gui.onFinishChange( event => {
+	 * 	event.object     // object that was modified
+	 * 	event.property   // string, name of property
+	 * 	event.value      // new value of controller
+	 * 	event.controller // controller that was modified
+	 * } );
+	 */
+	onFinishChange( callback ) {
+		this._onFinishChange = callback;
+		return this;
+	}
+
+	_callOnFinishChange( controller ) {
+
+		if ( this.parent ) {
+			this.parent._callOnFinishChange( controller );
+		}
+
+		if ( this._onFinishChange !== undefined ) {
+			this._onFinishChange.call( this, {
+				object: controller.object,
+				property: controller.property,
+				value: controller.getValue(),
+				controller
+			} );
+		}
+	}
+
+	/**
 	 * Destroys all DOM elements and event listeners associated with this GUI
 	 */
 	destroy() {

--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -56,8 +56,8 @@ export default class NumberController extends Controller {
 	_initInput() {
 
 		this.$input = document.createElement( 'input' );
-		this.$input.setAttribute( 'type', 'text' );
-		this.$input.setAttribute( 'inputmode', 'decimal' );
+		this.$input.setAttribute( 'type', 'number' );
+		this.$input.setAttribute( 'step', 'any' );
 		this.$input.setAttribute( 'aria-labelledby', this.$name.id );
 
 		this.$widget.appendChild( this.$input );

--- a/style/controllers.scss
+++ b/style/controllers.scss
@@ -54,10 +54,7 @@
 					position: absolute;
 					border-radius: var(--widget-border-radius);
 					border: 1px solid #fff9;
-					left: 0;
-					right: 0;
-					top: 0;
-					bottom: 0;
+					inset: 0;
 				}
 			}
 		}
@@ -111,9 +108,7 @@
 				font-family: 'lil-gui';
 				content: '↕';
 				position: absolute;
-				top: 0;
-				right: 0;
-				bottom: 0;
+				inset: 0 0 0 auto;
 				padding-right: 0.375em;
 			}
 		}

--- a/style/controllers.scss
+++ b/style/controllers.scss
@@ -14,7 +14,9 @@
 			}
 		}
 
-		.name {
+		// > is used here to avoid styling FunctionController's .name,
+		// which gets put inside of its widget.
+		> .name {
 			min-width: var(--name-width);
 			flex-shrink: 0;
 			white-space: pre;
@@ -29,11 +31,6 @@
 			width: 100%;
 			min-height: var(--widget-height);
 		}
-	}
-
-	.controller.function .name {
-		line-height: unset;
-		padding: 0;
 	}
 
 	.controller.string input {

--- a/style/icons/u2195-dropdown.svg
+++ b/style/icons/u2195-dropdown.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="100px" height="100px" viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
 <g>
-	<polygon points="24.6,40.3 50,14.9 75.4,40.3 	"/>
-	<polygon points="75.4,59.7 50,85.1 24.6,59.7 	"/>
+	<polygon points="24.6,44.3 50,18.9 75.4,44.3 	"/>
+	<polygon points="75.4,63.7 50,89.1 24.6,63.7 	"/>
 </g>
 </svg>

--- a/style/inputs.scss
+++ b/style/inputs.scss
@@ -40,6 +40,7 @@
 		width: var(--checkbox-size);
 		border-radius: var(--widget-border-radius);
 		text-align: center;
+		cursor: pointer;
 		&:checked:before {
 			font-family: 'lil-gui';
 			content: '✓';

--- a/style/inputs.scss
+++ b/style/inputs.scss
@@ -21,6 +21,9 @@
 				background: var(--focus-color);
 			}
 		}
+		&:disabled { 
+			opacity: 1; // override default iOS style, we already dim .controller
+		}
 	}
 
 	input[type='text'] {

--- a/style/inputs.scss
+++ b/style/inputs.scss
@@ -89,10 +89,7 @@
 
 		text-align: center;
 
-		// tried to center vertically via flex, didn't work...
-		// shouldn't this just be 1? focus border makes this weird
-		// .725 seemed to line up for mobile & desktop
-		line-height: calc(var(--widget-height) * 0.725);
+		line-height: calc(var(--widget-height) - 4px);
 
 		@include can-hover {
 			&:hover {

--- a/style/inputs.scss
+++ b/style/inputs.scss
@@ -26,11 +26,24 @@
 		}
 	}
 
-	input[type='text'] {
+	input[type='text'],
+	input[type='number'] {
 		padding: var(--widget-padding);
 		&:focus {
 			background: var(--focus-color);
 		}
+	}
+
+	// Hide number spinners
+
+	input::-webkit-outer-spin-button,
+	input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+	
+	input[type='number'] {
+		-moz-appearance: textfield;
 	}
 
 	input[type='checkbox'] {
@@ -53,7 +66,6 @@
 				box-shadow: inset 0 0 0 1px var(--focus-color);
 			}
 		}
-
 	}
 
 	button {


### PR DESCRIPTION
Public facing changes: https://github.com/georgealways/lil-gui/blob/dev/Changelog.md#0140

Internal changes:
- Number controller input now uses `type="number"` instead of `type="text" inputmode="decimal"`:
#16 
- Added TypeScript `d.ts` generation task, which is only run on prepublish.