### PR TITLE
Typing in inputs won't trigger other key listeners

### DIFF
--- a/src/ColorController.js
+++ b/src/ColorController.js
@@ -60,6 +60,8 @@ export default class ColorController extends Controller {
 
 		this.$disable = this.$text;
 
+		this._captureKeyEvents( this.$text );
+
 		this.updateDisplay();
 
 	}

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -374,4 +374,15 @@ export default class Controller {
 		this.parent.$children.removeChild( this.domElement );
 	}
 
+	/**
+	 * Stops propagation of `keyup` and `keydown` events for `el`. Used on inputs
+	 * that allow typing to prevent triggering global key commands.
+	 * @param {HTMLElement} el
+	 * @protected
+	 */
+	_captureKeyEvents( el ) {
+		el.addEventListener( 'keydown', e => e.stopPropagation() );
+		el.addEventListener( 'keyup', e => e.stopPropagation() );
+	}
+
 }

--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -65,6 +65,8 @@ export default class NumberController extends Controller {
 
 		this.$disable = this.$input;
 
+		this._captureKeyEvents( this.$input );
+
 		const onInput = () => {
 
 			const value = parseFloat( this.$input.value );

--- a/src/StringController.js
+++ b/src/StringController.js
@@ -28,6 +28,8 @@ export default class StringController extends Controller {
 
 		this.$disable = this.$input;
 
+		this._captureKeyEvents( this.$input );
+
 		this.updateDisplay();
 
 	}

--- a/tests/utils/shim.js
+++ b/tests/utils/shim.js
@@ -26,6 +26,7 @@ class EventTarget {
 		const listeners = this.__eventListeners[ name ];
 		if ( !listeners ) return;
 		event.preventDefault = function() {};
+		event.stopPropagation = function() {};
 		listeners.forEach( l => l( event ) );
 	}
 


### PR DESCRIPTION
Fixes #22. Any input you can type in calls `stopPropagation` on `keyup` and `keydown`. There's an argument to be made for this being optional behavior: I can think of a case where a user might want to respond to key events that propagate while typing (for example, preventing default on ctrl+Z to implement a custom undo for the GUI). For now, it's not optional: accidental triggering of key commands while typing is probably a much more common problem, and I'd like to avoid the complexity of another GUI constructor param.