### PR TITLE
`listen()` only updates display on value change

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 0.16.0-dev
+
+29.14kb, 8.31kb gzipped
+
+- Improved performance for GUI's that make heavy use of `listen()`.
+
 # 0.16.0
 
 29.05kb, 8.28kb gzipped

--- a/examples/listen-stress/index.html
+++ b/examples/listen-stress/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<title>lil-gui - Basic Example</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+	<script src="https://cdn.jsdelivr.net/npm/stats.js"></script>
+	<script type="module" src="listen-stress.js"></script>
+</body>
+</html>

--- a/examples/listen-stress/listen-stress.js
+++ b/examples/listen-stress/listen-stress.js
@@ -1,0 +1,83 @@
+/* global Stats */
+import GUI from '../../dist/lil-gui.esm.js';
+
+const params = {
+	count: parseInt( location.search.substring( 1 ) ) || 10,
+	animateAll: false,
+	update() {
+
+		let diff = params.count - folder.controllers.length;
+
+		for ( ; diff < 0; diff++ ) {
+			folder.controllers.at( -1 ).destroy();
+		}
+
+		for ( ; diff > 0; diff-- ) {
+			const i = folder.controllers.length % dummyControllers.length;
+			const controller = dummyControllers[ i ]();
+			controller.listen();
+		}
+
+		folder.title( params.count + ' Listening Controllers' );
+
+		history.replaceState( {}, '', '?' + params.count );
+
+	}
+};
+
+const dummyControllers = [
+	() => folder.add( dummyParams, 'options', { Small: 1, Medium: 10, Large: 100 } ),
+	() => folder.add( dummyParams, 'boolean' ),
+	() => folder.add( dummyParams, 'string' ),
+	() => folder.add( dummyParams, 'number', 0, 1 ),
+	() => folder.addColor( dummyParams, 'color' )
+];
+
+const dummyParams = {
+	options: 10,
+	boolean: true,
+	string: 'lil-gui',
+	number: 0,
+	color: { r: 1, g: 0, b: 1 }
+};
+
+let frame = 0;
+function animate() {
+
+	stats.end();
+	stats.begin();
+
+	if ( params.animateAll ) {
+
+		const time = Date.now() / 1000;
+
+		dummyParams.options = [ 1, 10, 100 ][ frame % 3 ];
+		dummyParams.boolean = frame % 2;
+		dummyParams.string = time.toString();
+		dummyParams.number = time % 1;
+
+		dummyParams.color.r = Math.sin( time / 2 ) / 2 + 0.5;
+		dummyParams.color.g = Math.sin( time / 3 ) / 2 + 0.5;
+		dummyParams.color.b = Math.sin( time / 5 ) / 2 + 0.5;
+
+		frame++;
+
+	}
+
+	requestAnimationFrame( animate );
+
+}
+
+const gui = new GUI();
+
+gui.add( params, 'animateAll' );
+gui.add( params, 'count' ).min( 0 );
+gui.add( params, 'update' );
+
+const folder = gui.addFolder();
+
+const stats = new Stats();
+document.body.appendChild( stats.dom );
+
+params.update();
+animate();

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -317,12 +317,21 @@ export default class Controller {
 	}
 
 	_listenCallback() {
+
 		this._listenCallbackID = requestAnimationFrame( this._listenCallback );
+
+		// To prevent framerate loss, make sure the value has changed before updating the display.
+		// Note: save() is used here instead of getValue() only because of ColorController. The !== operator
+		// won't work for color objects or arrays, but ColorController.save() always returns a string.
+
 		const curValue = this.save();
+
 		if ( curValue !== this._listenPrevValue ) {
 			this.updateDisplay();
 		}
+
 		this._listenPrevValue = curValue;
+
 	}
 
 	/**

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -318,7 +318,11 @@ export default class Controller {
 
 	_listenCallback() {
 		this._listenCallbackID = requestAnimationFrame( this._listenCallback );
-		this.updateDisplay();
+		const curValue = this.save();
+		if ( curValue !== this._listenPrevValue ) {
+			this.updateDisplay();
+		}
+		this._listenPrevValue = curValue;
 	}
 
 	/**


### PR DESCRIPTION
`listen` stores the controller's previous value and only calls `updateDisplay` if the value has changed. Should alleviate #35.

Originally I thought that redundant assignments to an HTML input's `value` were free, and that the bottleneck was each controller making its own animation frame request. It turns out consolidating the loops didn't really have an impact on performance.

With this PR, `listen` has negligible performance impact until values actually change: I'm able to add 1000 non-updating (yet listening) controllers in the new `examples/listen-stress` demo without dropping frames (2018 MPB). I'm able to get around 80 _continuously_ updating controllers, but I think this bottleneck is browser-side.