### PR TITLE
Controller.show() / hide()

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -33,6 +33,13 @@ export default class Controller {
 		this._disabled = false;
 
 		/**
+		 * Used to determine if the Controller is hidden.
+		 * Use `controller.show()` or `controller.hide()` to change this.
+		 * @type {boolean}
+		 */
+		this._hidden = false;
+
+		/**
 		 * The value of `object[ property ]` when the controller was created.
 		 * @type {any}
 		 */
@@ -223,6 +230,33 @@ export default class Controller {
 
 		return this;
 
+	}
+
+	/**
+	 * Shows the Controller after it's been hidden.
+	 * @param {boolean} show
+	 * @returns {this}
+	 * @example
+	 * controller.show();
+	 * controller.show( false ); // hide
+	 * controller.show( controller._hidden ); // toggle
+	 */
+	show( show = true ) {
+
+		this._hidden = !show;
+
+		this.domElement.style.display = this._hidden ? 'none' : '';
+
+		return this;
+
+	}
+
+	/**
+	 * Hides the Controller.
+	 * @returns {this}
+	 */
+	hide() {
+		return this.show( false );
 	}
 
 	/**

--- a/tests/controller-show.js
+++ b/tests/controller-show.js
@@ -8,22 +8,22 @@ export default () => {
 
 	assert.strictEqual( controller.domElement.style.display, undefined, 'Undefined by default' );
 
-  controller.show()
+	controller.show();
 	assert.strictEqual( controller.domElement.style.display, '', 'Shown after call to .show()' );
 
-  controller.hide()
+	controller.hide();
 	assert.strictEqual( controller.domElement.style.display, 'none', 'Hidden after call to .hide()' );
 
-  controller.show( true )
+	controller.show( true );
 	assert.strictEqual( controller.domElement.style.display, '', 'Shown after call to .show(true)' );
 
-  controller.show( false )
+	controller.show( false );
 	assert.strictEqual( controller.domElement.style.display, 'none', 'Hidden after call to .show(false)' );
 
-  controller.show( controller._hidden )
+	controller.show( controller._hidden );
 	assert.strictEqual( controller.domElement.style.display, '', 'Shown after toggle' );
 
-  controller.show( controller._hidden )
+	controller.show( controller._hidden );
 	assert.strictEqual( controller.domElement.style.display, 'none', 'Hidden after toggle' );
 
 };

--- a/tests/controller-show.js
+++ b/tests/controller-show.js
@@ -1,0 +1,29 @@
+import assert from 'assert';
+import GUI from '..';
+
+export default () => {
+
+	const gui = new GUI();
+	const controller = gui.add( { x: 0 }, 'x' );
+
+	assert.strictEqual( controller.domElement.style.display, undefined, 'Undefined by default' );
+
+  controller.show()
+	assert.strictEqual( controller.domElement.style.display, '', 'Shown after call to .show()' );
+
+  controller.hide()
+	assert.strictEqual( controller.domElement.style.display, 'none', 'Hidden after call to .hide()' );
+
+  controller.show( true )
+	assert.strictEqual( controller.domElement.style.display, '', 'Shown after call to .show(true)' );
+
+  controller.show( false )
+	assert.strictEqual( controller.domElement.style.display, 'none', 'Hidden after call to .show(false)' );
+
+  controller.show( controller._hidden )
+	assert.strictEqual( controller.domElement.style.display, '', 'Shown after toggle' );
+
+  controller.show( controller._hidden )
+	assert.strictEqual( controller.domElement.style.display, 'none', 'Hidden after toggle' );
+
+};


### PR DESCRIPTION
Remake of #55 after it was accidentally merged to master. Adds `show()` and `hide()` to Controllers.