### PR TITLE
Typing in number fields respects step (if set)

### DIFF
--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -76,9 +76,13 @@ export default class NumberController extends Controller {
 
 		const onInput = () => {
 
-			const value = parseFloat( this.$input.value );
+			let value = parseFloat( this.$input.value );
 
 			if ( isNaN( value ) ) return;
+
+			if ( this._stepExplicit ) {
+				value = this._snap( value );
+			}
 
 			this.setValue( this._clamp( value ) );
 

--- a/tests/number-input-step.js
+++ b/tests/number-input-step.js
@@ -1,0 +1,27 @@
+import assert from 'assert';
+import { GUI } from '..';
+
+export default () => {
+
+	const gui = new GUI();
+	const obj = { x: 0 };
+
+	let ctrl = gui.add( obj, 'x' );
+
+	ctrl.$input.value = '1.23456789';
+	ctrl.$input.$callEventListener( 'input' );
+	ctrl.$input.blur();
+
+	assert.strictEqual( obj.x, 1.23456789, 'All precision retained when typing with an undefined step' );
+	assert.equal( ctrl.$input.value, 1.23456789, 'All precision retained when typing with an undefined step' );
+
+	ctrl = gui.add( obj, 'x' ).step( 1 );
+
+	ctrl.$input.value = '1.9';
+	ctrl.$input.$callEventListener( 'input' );
+	ctrl.$input.blur();
+
+	assert.strictEqual( obj.x, 2, 'Numbers typed in the field are rounded to step' );
+	assert.equal( ctrl.$input.value, 2, 'Numbers typed in the field are rounded to step' );
+
+};


### PR DESCRIPTION
Fixes #62

User is still free to enter as much precision as they'd like if step hasn't been set.