### PR TITLE
Number Controller: use period instead of comma for decimal point regardless of locale settings

### DIFF
--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -65,9 +65,26 @@ export default class NumberController extends Controller {
 
 	_initInput() {
 
+		// Detect if the device has touch as his primary pointer input.
+		// This will targets only phones and tablets.
+		const hasTouchAsPrimaryPointerInput = window.matchMedia( '(pointer: coarse)' ).matches;
+
 		this.$input = document.createElement( 'input' );
-		this.$input.setAttribute( 'type', 'number' );
-		this.$input.setAttribute( 'step', 'any' );
+
+		if ( hasTouchAsPrimaryPointerInput ) {
+
+			// Only use type number for touch device in order to show a fully functional numeric keyboard
+			this.$input.setAttribute( 'type', 'number' );
+			this.$input.setAttribute( 'step', 'any' );
+
+		} else {
+
+			// Otherwise use a text input on Desktop to prevent the field displaying a comma instead of a period for countries that use comma as decimal mark
+			// https://docs.moodle.org/dev/Decimal_separator#Countries_where_a_comma_.22.2C.22_is_used_as_decimal_mark:
+			this.$input.setAttribute( 'type', 'text' );
+
+		}
+
 		this.$input.setAttribute( 'aria-labelledby', this.$name.id );
 
 		this.$widget.appendChild( this.$input );

--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -65,27 +65,21 @@ export default class NumberController extends Controller {
 
 	_initInput() {
 
-		// Detect if the device has touch as his primary pointer input.
-		// This will targets only phones and tablets.
-		const hasTouchAsPrimaryPointerInput = window.matchMedia( '(pointer: coarse)' ).matches;
-
 		this.$input = document.createElement( 'input' );
+		this.$input.setAttribute( 'type', 'text' );
+		this.$input.setAttribute( 'aria-labelledby', this.$name.id );
 
-		if ( hasTouchAsPrimaryPointerInput ) {
+		// On touch devices only, use input[type=number] to force a numeric keyboard.
+		// Ideally we could use one input type everywhere, but [type=number] has quirks
+		// on desktop, and [inputmode=decimal] has quirks on iOS.
+		// See https://github.com/georgealways/lil-gui/pull/16
 
-			// Only use type number for touch device in order to show a fully functional numeric keyboard
+		const isTouch = window.matchMedia( '(pointer: coarse)' ).matches;
+
+		if ( isTouch ) {
 			this.$input.setAttribute( 'type', 'number' );
 			this.$input.setAttribute( 'step', 'any' );
-
-		} else {
-
-			// Otherwise use a text input on Desktop to prevent the field displaying a comma instead of a period for countries that use comma as decimal mark
-			// https://docs.moodle.org/dev/Decimal_separator#Countries_where_a_comma_.22.2C.22_is_used_as_decimal_mark:
-			this.$input.setAttribute( 'type', 'text' );
-
 		}
-
-		this.$input.setAttribute( 'aria-labelledby', this.$name.id );
 
 		this.$widget.appendChild( this.$input );
 

--- a/tests/utils/shim.js
+++ b/tests/utils/shim.js
@@ -79,7 +79,7 @@ function createElement( tag ) {
 }
 
 global.window = new EventTarget();
-global.window.matchMedia = () => { return { matches: true } };
+global.window.matchMedia = () => { return { matches: true }; };
 global.requestAnimationFrame = fnc => setTimeout( fnc, 100 / 6 );
 global.cancelAnimationFrame = id => clearTimeout( id );
 

--- a/tests/utils/shim.js
+++ b/tests/utils/shim.js
@@ -79,6 +79,7 @@ function createElement( tag ) {
 }
 
 global.window = new EventTarget();
+global.window.matchMedia = () => { return { matches: true } };
 global.requestAnimationFrame = fnc => setTimeout( fnc, 100 / 6 );
 global.cancelAnimationFrame = id => clearTimeout( id );
 


### PR DESCRIPTION
Following the discussion in #16, Here's my take on how to fix the comma / period problem in Number controllers.

This PR greatly improves the experience for the users of these [74 countries](https://docs.moodle.org/dev/Decimal_separator#Countries_where_a_comma_.22.2C.22_is_used_as_decimal_mark:) since it's currently not possible for us to simply copy / paste values from a lil-gui number field to our code without having to manually replace the comma with a period.

This fix make sure that:

- Mobile and tablet users have a fully functional numeric keyboard when interacting with a Number controller.
- Chrome Desktop users from countries that use comma as decimal mark (even when using a touch screen) always see decimal values separated with a period.

Without the fix on Chrome Desktop:

![Screenshot 2022-12-19 at 13 59 51](https://user-images.githubusercontent.com/1268691/208439343-dd1ec493-9149-4ed4-a557-e8e0e48d8505.png)
After the fix:

![Screenshot 2022-12-19 at 13 59 57](https://user-images.githubusercontent.com/1268691/208439380-46a63a11-ca44-4aa7-9164-9dfa0c8907ed.png)
While keeping the numeric keyboard on mobile:

![IMG_BAE4200CD36D-1](https://user-images.githubusercontent.com/1268691/208439613-50bee1ca-f67f-4085-8ef5-d039b7a99a45.jpeg)

Let me know if you have any questions regarding the changes, I tried to be as concise as possible.
Thanks.