### PR TITLE
Allowed users to disable mouse wheel for NumberControl

### DIFF
--- a/src/GUI.js
+++ b/src/GUI.js
@@ -177,9 +177,10 @@ export default class GUI {
 			this.domElement.style.setProperty( '--width', width + 'px' );
 		}
 
-		// Don't fire global key events while typing in the GUI:
-		this.domElement.addEventListener( 'keydown', e => e.stopPropagation() );
-		this.domElement.addEventListener( 'keyup', e => e.stopPropagation() );
+		// Users should add their own if they want to prevent firing...
+		// otherwise their shortcuts will be messed up
+		// this.domElement.addEventListener( 'keydown', e => e.stopPropagation() );
+		// this.domElement.addEventListener( 'keyup', e => e.stopPropagation() );
 
 	}
 

--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -8,6 +8,8 @@ export default class NumberController extends Controller {
 
 		this._initInput();
 
+		this._sliderWheelEnabled = true;
+
 		this.min( min );
 		this.max( max );
 
@@ -361,6 +363,9 @@ export default class NumberController extends Controller {
 		let wheelFinishChangeTimeout;
 
 		const onWheel = e => {
+			
+			// ignore wheels if user disables it
+			if( !this._sliderWheelEnabled ) return;
 
 			// ignore vertical wheels if there's a scrollbar
 			const isVertical = Math.abs( e.deltaX ) < Math.abs( e.deltaY );


### PR DESCRIPTION
Should fix https://github.com/georgealways/lil-gui/issues/83

This fix is tentative, please change it however you want : )

The goal is to set a explicit flag so `onwheel` listener will ignore mouse wheel

```js
c._sliderWheelEnabled = false;
```