### PR TITLE
Remove side effect false alarm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "dist/lil-gui.esm.js",
   "main": "dist/lil-gui.umd.js",
   "types": "dist/lil-gui.esm.d.ts",
+  "sideEffects": false,
   "config": {
     "style": "dist/lil-gui.css",
     "styleMin": "dist/lil-gui.min.css"

--- a/src/utils/getColorFormat.js
+++ b/src/utils/getColorFormat.js
@@ -16,7 +16,7 @@ const INT = {
 
 const ARRAY = {
 	isPrimitive: false,
-	match: Array.isArray,
+	match: v => Array.isArray( v ),
 	fromHexString( string, target, rgbScale = 1 ) {
 
 		const int = INT.fromHexString( string );

--- a/src/utils/getColorFormat.js
+++ b/src/utils/getColorFormat.js
@@ -16,7 +16,11 @@ const INT = {
 
 const ARRAY = {
 	isPrimitive: false,
+	
+	// The arrow function is here to appease tree shakers like esbuild or webpack.
+	// See https://esbuild.github.io/api/#tree-shaking
 	match: v => Array.isArray( v ),
+	
 	fromHexString( string, target, rgbScale = 1 ) {
 
 		const int = INT.fromHexString( string );


### PR DESCRIPTION
I'm using lil-gui in an app bundled with [esbuild](https://esbuild.github.io). It works great, except when I bundle for production esbuild isn't able to fully tree shake away lil-gui. There are two fixes for that, both of which I've included in this PR:

1. Add `"sideEffects": false` to `package.json`, which tells esbuild to ignore any potential side effects. (This isn't an esbuild-specific feature; [Webpack supports this too](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).)
2. In `src/utils/getColorFormat.js`, wrap `ARRAY.match: Array.isArray` in a function. [esbuild considers using `Array.isArray` directly a potential side effect](https://esbuild.github.io/api/#tree-shaking-and-side-effects), since property access could technically run code in a getter.

Either/both of these will work; I'd prefer at least the second solution, since tools like esbuild also provide the option to ignore annotations like `"sideEffects": false`.