### PR TITLE
Fix type errors

### DIFF
--- a/src/BooleanController.js
+++ b/src/BooleanController.js
@@ -1,5 +1,7 @@
 import Controller from './Controller';
 
+/* eslint-disable jsdoc/require-description */
+
 export default class BooleanController extends Controller {
 
 	constructor( parent, object, property ) {
@@ -23,6 +25,9 @@ export default class BooleanController extends Controller {
 
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	updateDisplay() {
 		this.$input.checked = this.getValue();
 		return this;

--- a/src/ColorController.js
+++ b/src/ColorController.js
@@ -3,6 +3,8 @@ import Controller from './Controller';
 import getColorFormat from './utils/getColorFormat';
 import normalizeColorString from './utils/normalizeColorString';
 
+/* eslint-disable jsdoc/require-description */
+
 export default class ColorController extends Controller {
 
 	constructor( parent, object, property, rgbScale ) {
@@ -64,6 +66,9 @@ export default class ColorController extends Controller {
 
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	reset() {
 		this._setValueFromHexString( this._initialValueHexString );
 		return this;
@@ -96,6 +101,9 @@ export default class ColorController extends Controller {
 		return this;
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	updateDisplay() {
 		this.$input.value = this._format.toHexString( this.getValue(), this._rgbScale );
 		if ( !this._textFocused ) {

--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -1,5 +1,7 @@
 import Controller from './Controller';
 
+/* eslint-disable jsdoc/require-description, jsdoc/require-param */
+
 export default class NumberController extends Controller {
 
 	constructor( parent, object, property, min, max, step ) {
@@ -18,30 +20,45 @@ export default class NumberController extends Controller {
 
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	decimals( decimals ) {
 		this._decimals = decimals;
 		this.updateDisplay();
 		return this;
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	min( min ) {
 		this._min = min;
 		this._onUpdateMinMax();
 		return this;
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	max( max ) {
 		this._max = max;
 		this._onUpdateMinMax();
 		return this;
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	step( step, explicit = true ) {
 		this._step = step;
 		this._stepExplicit = explicit;
 		return this;
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	updateDisplay() {
 
 		const value = this.getValue();

--- a/src/OptionController.js
+++ b/src/OptionController.js
@@ -1,5 +1,7 @@
 import Controller from './Controller';
 
+/* eslint-disable jsdoc/require-description */
+
 export default class OptionController extends Controller {
 
 	constructor( parent, object, property, options ) {
@@ -43,6 +45,9 @@ export default class OptionController extends Controller {
 
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	updateDisplay() {
 		const value = this.getValue();
 		const index = this._values.indexOf( value );

--- a/src/StringController.js
+++ b/src/StringController.js
@@ -1,5 +1,7 @@
 import Controller from './Controller';
 
+/* eslint-disable jsdoc/require-description */
+
 export default class StringController extends Controller {
 
 	constructor( parent, object, property ) {
@@ -32,6 +34,9 @@ export default class StringController extends Controller {
 
 	}
 
+	/**
+	 * @returns {this}
+	 */
 	updateDisplay() {
 		this.$input.value = this.getValue();
 		return this;


### PR DESCRIPTION
Resolves #93.

### Explanation

It seems that newer versions of TypeScript are a little more eager to include overriding members in derived classes.

Typescript 4.5:

```ts
export class BooleanController extends Controller {
    constructor(parent: any, object: any, property: any);
    $input: HTMLInputElement;
}
```

TypeScript 4.6:

```ts
export class BooleanController extends Controller {
    constructor(parent: any, object: any, property: any);
    $input: HTMLInputElement;
    $disable: HTMLInputElement;
    updateDisplay(): BooleanController;
}
```

This causes issues because`updateDisplay` needs to return `this`, not just any `BooleanController`.

TypeScript was upgraded in https://github.com/georgealways/lil-gui/commit/763a2217b0f4ef3b0098e4d58e510b2407f5000b which introduced this issue.

### Changes

This PR adds JSDoc comments to all the overriding methods that return `this` in order to fix the type errors. The duplication seems unfortunate, but not sure what other options there are.