### PR TITLE
Lock TypeScript to 4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "rollup": "^1.17.0",
         "sass": "^1.22.10",
         "terser": "^4.3.8",
-        "typescript": "^4.5.2",
+        "typescript": "~4.5.5",
         "webfont": "^11.2.26"
       }
     },
@@ -563,6 +563,19 @@
       },
       "engines": {
         "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/browser-sync-client/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/browser-sync-ui": {
@@ -5600,9 +5613,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6523,6 +6536,12 @@
           "requires": {
             "symbol-observable": "1.0.1"
           }
+        },
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
         }
       }
     },
@@ -10283,9 +10302,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rollup": "^1.17.0",
     "sass": "^1.22.10",
     "terser": "^4.3.8",
-    "typescript": "^4.5.2",
+    "typescript": "~4.5.5",
     "webfont": "^11.2.26"
   },
   "eslintIgnore": [


### PR DESCRIPTION
Just opening this as another potential resolution to https://github.com/georgealways/lil-gui/issues/93.

Resolves #93.

See https://github.com/georgealways/lil-gui/pull/95 for explanation.