### PR TITLE
remove esm, use native nodejs module loading

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -56,7 +56,7 @@ overrides:
     env:
       node: true
     parserOptions:
-      ecmaVersion: 9
+      ecmaVersion: 2022
   - files: [ src/**/*.js, tests/*.test.js ]
     rules:
       no-console: warn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lil-gui",
-  "version": "0.18.0",
+  "version": "0.18.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lil-gui",
-      "version": "0.18.0",
+      "version": "0.18.0-dev",
       "license": "MIT",
       "devDependencies": {
         "browser-sync": "^2.27.7",
@@ -14,7 +14,6 @@
         "cssnano": "^5.0.12",
         "eslint": "^8.1.0",
         "eslint-plugin-jsdoc": "^37.0.3",
-        "esm": "^3.2.25",
         "handlebars": "^4.3.1",
         "highlight.js": "^10.7.3",
         "jsdoc-api": "^5.0.2",
@@ -1860,15 +1859,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/espree": {
@@ -7478,12 +7468,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
       "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
-      "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "espree": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   },
   "description": "Makes a floating panel for controllers on the web.",
   "homepage": "https://lil-gui.georgealways.com",
+  "type": "module",
+  "exports": "./dist/lil-gui.esm.js",
   "module": "dist/lil-gui.esm.js",
   "main": "dist/lil-gui.umd.js",
   "types": "dist/lil-gui.esm.d.ts",
@@ -21,16 +23,16 @@
     "postcss": "postcss dist/lil-gui.css -u postcss-combine-media-query -u cssnano --no-map -o dist/lil-gui.min.css",
     "rollup": "rollup -c",
     "lint": "eslint .",
-    "icons": "node -r esm scripts/icons.js",
-    "test": "node -r esm tests/utils/runner.js",
-    "api": "node -r esm scripts/api.js --write",
+    "icons": "node scripts/icons.js",
+    "test": "node tests/utils/runner.js",
+    "api": "node scripts/api.js --write",
     "types": "tsc dist/lil-gui.esm.js --declaration --allowJs --emitDeclarationOnly --outDir dist",
-    "homepage": "node -r esm scripts/homepage.js",
+    "homepage": "node scripts/homepage.js",
     "server": "browser-sync start -s -f 'dist' 'index.html' 'homepage' 'examples' --no-open --no-notify --no-ui --no-ghost-mode --no-inject-changes",
     "clean": "rimraf -rf dist index.html API.md style/icons.scss",
     "preversion": "npm run build && npm test",
     "prepublishOnly": "npm run clean && npm run build && npm run types && npm test",
-    "dev": "npm run build:all && node -r esm scripts/dev.js"
+    "dev": "npm run build:all && node scripts/dev.js"
   },
   "files": [
     "dist"
@@ -42,7 +44,6 @@
     "cssnano": "^5.0.12",
     "eslint": "^8.1.0",
     "eslint-plugin-jsdoc": "^37.0.3",
-    "esm": "^3.2.25",
     "handlebars": "^4.3.1",
     "highlight.js": "^10.7.3",
     "jsdoc-api": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "description": "Makes a floating panel for controllers on the web.",
   "homepage": "https://lil-gui.georgealways.com",
   "type": "module",
-  "exports": "./dist/lil-gui.esm.js",
   "module": "dist/lil-gui.esm.js",
   "main": "dist/lil-gui.umd.js",
   "types": "dist/lil-gui.esm.d.ts",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,5 +1,5 @@
 import concurrently from 'concurrently';
-import pkg from '../package.json';
+import pkg from './package.js';
 
 dev( {
 	'api': {

--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -4,8 +4,8 @@ import hljs from 'highlight.js';
 import hbs from 'handlebars';
 import { execSync } from 'child_process';
 
-import pkg from '../package.json';
-import jsdocData from './api';
+import pkg from './package.js';
+import jsdocData from './api.js';
 
 const OUTPUT = 'index.html';
 const TEMPLATE = 'homepage/homepage.hbs.html';

--- a/scripts/icons.js
+++ b/scripts/icons.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import webfont from 'webfont';
+import { webfont } from 'webfont';
 
 const INPUT = 'style/icons/*.svg';
 const OUTPUT = 'style/icons.scss';

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -1,3 +1,3 @@
-// because you still need a law degree to import a json file in node 18
+// workaround to import json without warnings from node@18 and eslint
 import fs from 'fs';
 export default JSON.parse( fs.readFileSync( './package.json' ) );

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -1,0 +1,3 @@
+// because you still need a law degree to import a json file in node 18
+import fs from 'fs';
+export default JSON.parse( fs.readFileSync( './package.json' ) );

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -1,3 +1,6 @@
 // workaround to import json without warnings from node@18 and eslint
+// https://github.com/eslint/eslint/discussions/15305
+
 import fs from 'fs';
+
 export default JSON.parse( fs.readFileSync( './package.json' ) );

--- a/src/utils/getColorFormat.js
+++ b/src/utils/getColorFormat.js
@@ -16,11 +16,11 @@ const INT = {
 
 const ARRAY = {
 	isPrimitive: false,
-	
+
 	// The arrow function is here to appease tree shakers like esbuild or webpack.
 	// See https://esbuild.github.io/api/#tree-shaking
 	match: v => Array.isArray( v ),
-	
+
 	fromHexString( string, target, rgbScale = 1 ) {
 
 		const int = INT.fromHexString( string );

--- a/src/utils/getColorFormat.js
+++ b/src/utils/getColorFormat.js
@@ -20,7 +20,7 @@ const ARRAY = {
 	// The arrow function is here to appease tree shakers like esbuild or webpack.
 	// See https://esbuild.github.io/api/#tree-shaking
 	match: v => Array.isArray( v ),
-
+	
 	fromHexString( string, target, rgbScale = 1 ) {
 
 		const int = INT.fromHexString( string );

--- a/src/utils/getColorFormat.js
+++ b/src/utils/getColorFormat.js
@@ -16,11 +16,11 @@ const INT = {
 
 const ARRAY = {
 	isPrimitive: false,
-
+	
 	// The arrow function is here to appease tree shakers like esbuild or webpack.
 	// See https://esbuild.github.io/api/#tree-shaking
 	match: v => Array.isArray( v ),
-	
+
 	fromHexString( string, target, rgbScale = 1 ) {
 
 		const int = INT.fromHexString( string );

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -7,7 +7,7 @@ import GUI,
 	FunctionController,
 	NumberController,
 	OptionController
-} from '..';
+} from 'lil-gui';
 
 export default () => {
 

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -7,7 +7,7 @@ import GUI,
 	FunctionController,
 	NumberController,
 	OptionController
-} from 'lil-gui';
+} from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -7,7 +7,7 @@ import GUI,
 	FunctionController,
 	NumberController,
 	OptionController
-} from '../dist/lil-gui.esm.min.js';
+} from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/close-folders.js
+++ b/tests/close-folders.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/close-folders.js
+++ b/tests/close-folders.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/close-folders.js
+++ b/tests/close-folders.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/close-folders.js
+++ b/tests/close-folders.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/color-parsing.js
+++ b/tests/color-parsing.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/color-parsing.js
+++ b/tests/color-parsing.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/color-parsing.js
+++ b/tests/color-parsing.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/color-reset.js
+++ b/tests/color-reset.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/color-reset.js
+++ b/tests/color-reset.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/color-reset.js
+++ b/tests/color-reset.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/color-reset.js
+++ b/tests/color-reset.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/controller-load.js
+++ b/tests/controller-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/controller-load.js
+++ b/tests/controller-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/controller-load.js
+++ b/tests/controller-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/controller-load.js
+++ b/tests/controller-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/controller-show.js
+++ b/tests/controller-show.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/controller-show.js
+++ b/tests/controller-show.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/controller-show.js
+++ b/tests/controller-show.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/destroy.js
+++ b/tests/destroy.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
-import spy from './utils/spy';
+import spy from './utils/spy.js';
 
 export default () => {
 

--- a/tests/destroy.js
+++ b/tests/destroy.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 import spy from './utils/spy.js';
 

--- a/tests/destroy.js
+++ b/tests/destroy.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js';
 
 import spy from './utils/spy.js';
 

--- a/tests/number-arrow-wheel.js
+++ b/tests/number-arrow-wheel.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/number-arrow-wheel.js
+++ b/tests/number-arrow-wheel.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/number-arrow-wheel.js
+++ b/tests/number-arrow-wheel.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/number-arrow-wheel.js
+++ b/tests/number-arrow-wheel.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/number-decimals.js
+++ b/tests/number-decimals.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/number-decimals.js
+++ b/tests/number-decimals.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/number-decimals.js
+++ b/tests/number-decimals.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/number-decimals.js
+++ b/tests/number-decimals.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/number-finish-change.js
+++ b/tests/number-finish-change.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
-import simulateDrag from './utils/simulateDrag';
+import simulateDrag from './utils/simulateDrag.js';
 
 export default () => {
 

--- a/tests/number-finish-change.js
+++ b/tests/number-finish-change.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js';
 
 import simulateDrag from './utils/simulateDrag.js';
 

--- a/tests/number-finish-change.js
+++ b/tests/number-finish-change.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 import simulateDrag from './utils/simulateDrag.js';
 

--- a/tests/number-input-step.js
+++ b/tests/number-input-step.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { GUI } from '../dist/lil-gui.esm.min.js'
+import { GUI } from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/number-input-step.js
+++ b/tests/number-input-step.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { GUI } from '..';
+import { GUI } from 'lil-gui';
 
 export default () => {
 

--- a/tests/number-input-step.js
+++ b/tests/number-input-step.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { GUI } from '../dist/lil-gui.esm.min.js';
+import { GUI } from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/number-input-step.js
+++ b/tests/number-input-step.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { GUI } from 'lil-gui';
+import { GUI } from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/number-slider-precision.js
+++ b/tests/number-slider-precision.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/number-slider-precision.js
+++ b/tests/number-slider-precision.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/number-slider-precision.js
+++ b/tests/number-slider-precision.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/number-slider-precision.js
+++ b/tests/number-slider-precision.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/number-vertical-drag.js
+++ b/tests/number-vertical-drag.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
-import simulateDrag from './utils/simulateDrag';
+import simulateDrag from './utils/simulateDrag.js';
 
 export default () => {
 

--- a/tests/number-vertical-drag.js
+++ b/tests/number-vertical-drag.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js';
 
 import simulateDrag from './utils/simulateDrag.js';
 

--- a/tests/number-vertical-drag.js
+++ b/tests/number-vertical-drag.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 import simulateDrag from './utils/simulateDrag.js';
 

--- a/tests/on-change-controller.js
+++ b/tests/on-change-controller.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/on-change-controller.js
+++ b/tests/on-change-controller.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/on-change-controller.js
+++ b/tests/on-change-controller.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/on-change-controller.js
+++ b/tests/on-change-controller.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/on-change-gui.js
+++ b/tests/on-change-gui.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/on-change-gui.js
+++ b/tests/on-change-gui.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/on-change-gui.js
+++ b/tests/on-change-gui.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/on-open-close.js
+++ b/tests/on-open-close.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/on-open-close.js
+++ b/tests/on-open-close.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/on-open-close.js
+++ b/tests/on-open-close.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/reset-finish-change.js
+++ b/tests/reset-finish-change.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/reset-finish-change.js
+++ b/tests/reset-finish-change.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/reset-finish-change.js
+++ b/tests/reset-finish-change.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/reset-finish-change.js
+++ b/tests/reset-finish-change.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/save-load-errors.js
+++ b/tests/save-load-errors.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/save-load-errors.js
+++ b/tests/save-load-errors.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/save-load-errors.js
+++ b/tests/save-load-errors.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/save-load-errors.js
+++ b/tests/save-load-errors.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/save-load.js
+++ b/tests/save-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/save-load.js
+++ b/tests/save-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/save-load.js
+++ b/tests/save-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/save-load.js
+++ b/tests/save-load.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/traverse-children.js
+++ b/tests/traverse-children.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from 'lil-gui';
+import GUI from '../dist/lil-gui.esm.min.js'
 
 export default () => {
 

--- a/tests/traverse-children.js
+++ b/tests/traverse-children.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js';
+import GUI from '../dist/lil-gui.esm.js';
 
 export default () => {
 

--- a/tests/traverse-children.js
+++ b/tests/traverse-children.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '..';
+import GUI from 'lil-gui';
 
 export default () => {
 

--- a/tests/traverse-children.js
+++ b/tests/traverse-children.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GUI from '../dist/lil-gui.esm.min.js'
+import GUI from '../dist/lil-gui.esm.min.js';
 
 export default () => {
 

--- a/tests/utils/runner.js
+++ b/tests/utils/runner.js
@@ -1,36 +1,29 @@
 import './shim.js';
-
-import { AssertionError } from 'assert';
 import fs from 'fs';
 
 // run with --soft-fail to exit with code 0 even if tests don't pass
-
 const SOFT_FAIL = process.argv.includes( '--soft-fail' );
 
 console.time( 'tests' );
 
-// collect tests
-
-const tests = [];
-const testFiles = fs.readdirSync( 'tests' );
-
-for ( const filename of testFiles ) {
-	if ( !filename.endsWith( '.js' ) ) continue;
-	const test = await import( '../' + filename );
-	const name = filename.replace( '.js', '' );
-	tests.push( new Test( name, test.default ) );
-}
-
 // run tests
 
 let failures = 0;
-const numTests = tests.length;
 
-tests.forEach( t => t.run() );
+const tests = fs.readdirSync( 'tests' )
+	.filter( file => file.endsWith( '.js' ) )
+	.map( async file => {
+		const module = await import( '../' + file );
+		run( file, module.default );
+	} );
+
+await Promise.all( tests );
 
 // results
 
 console.timeEnd( 'tests' );
+
+const numTests = tests.length;
 
 if ( failures > 0 ) {
 	console.log( red( `✕ ${failures}/${numTests} tests failed` ) );
@@ -40,22 +33,14 @@ if ( failures > 0 ) {
 	process.exit( 0 );
 }
 
-function Test( name, test ) {
-	this.name = name;
-	this.run = () => {
-		try {
-			test();
-		} catch ( e ) {
-			failures++;
-			if ( e instanceof AssertionError ) {
-				console.log( red( `✕ ${e.message}` ) );
-				console.log( e.stack );
-			} else {
-				console.log( red( `✕ Unexpected error in test: ${this.name}` ) );
-				console.log( e.stack );
-			}
-		}
-	};
+function run( name, test ) {
+	try {
+		test();
+	} catch ( e ) {
+		failures++;
+		console.log( red( `Error in test: ${name}` ) );
+		console.log( e.stack );
+	}
 }
 
 function red( str ) { return `\x1b[31m${str}\x1b[0m`; }

--- a/tests/utils/runner.js
+++ b/tests/utils/runner.js
@@ -1,4 +1,4 @@
-import './shim';
+import './shim.js';
 
 import { AssertionError } from 'assert';
 import fs from 'fs';
@@ -12,16 +12,14 @@ console.time( 'tests' );
 // collect tests
 
 const tests = [];
-fs.readdirSync( 'tests' ).forEach( filename => {
+const testFiles = fs.readdirSync( 'tests' );
 
-	if ( !filename.endsWith( '.js' ) ) return;
-
-	const test = require( '../' + filename ).default;
+for ( const filename of testFiles ) {
+	if ( !filename.endsWith( '.js' ) ) continue;
+	const test = await import( '../' + filename );
 	const name = filename.replace( '.js', '' );
-
-	tests.push( new Test( name, test ) );
-
-} );
+	tests.push( new Test( name, test.default ) );
+}
 
 // run tests
 


### PR DESCRIPTION
ESM has been a scourge on the dev scripts in this codebase for a while. Early on it was preferable to node's `--experimental-module` flag (and it's module resolution is actually still a lot better) but there's a [major dealbreaker](https://github.com/standard-things/esm/issues/896): it vomits a wall of code anytime a runtime exception is encountered (in your code or elsewhere) making it impossible to see any error traces.

For a while I thought "hey I'm a JS developer, I'm good at blindly guessing what went wrong"—but recently I ran into some un-debuggable errors while trying to update dependencies and it was upsetting. I've decided to be kind to my future self and rip the band-aid.

What changed:

- Added a lot of `.js` to the end of local imports that didn't need them before.
- Unit tests are now importing the lib via relative path to the built esm module as opposed to `import '..'
- The test runner is using a dynamic import and a top-level await, hence the eslint `ecmaVersion` bump
- I couldn't get `assert { type: 'json' }` to work without upsetting eslint or rollup, hence `scripts/package.js` 🤢