### PR TITLE
controllers stop keystroke propagation instead of entire GUI

### DIFF
--- a/examples/kitchen-sink/kitchen-sink.js
+++ b/examples/kitchen-sink/kitchen-sink.js
@@ -2,6 +2,11 @@ import GUI from '../../dist/lil-gui.esm.js';
 
 export const container = document.getElementById( 'container' );
 
+const logKeyEvents = e => console.log( `window.${e.type}: ${e.key}` );
+
+window.addEventListener( 'keydown', logKeyEvents );
+window.addEventListener( 'keyup', logKeyEvents );
+
 /**
  * @param {object} options
  * @param {function(GUI):GUI?} callback

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -79,6 +79,10 @@ export default class Controller {
 		this.domElement.appendChild( this.$name );
 		this.domElement.appendChild( this.$widget );
 
+		// Don't fire global key events while typing in a controller
+		this.domElement.addEventListener( 'keydown', e => e.stopPropagation() );
+		this.domElement.addEventListener( 'keyup', e => e.stopPropagation() );
+
 		this.parent.children.push( this );
 		this.parent.controllers.push( this );
 

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -122,7 +122,6 @@ export default class GUI {
 		this.$title.addEventListener( 'click', () => this.openAnimated( this._closed ) );
 		this.$title.addEventListener( 'keydown', e => {
 			if ( e.code === 'Enter' || e.code === 'Space' ) {
-				e.stopPropagation();
 				this.$title.click();
 			}
 		} );

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -122,6 +122,7 @@ export default class GUI {
 		this.$title.addEventListener( 'click', () => this.openAnimated( this._closed ) );
 		this.$title.addEventListener( 'keydown', e => {
 			if ( e.code === 'Enter' || e.code === 'Space' ) {
+				e.preventDefault();
 				this.$title.click();
 			}
 		} );

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -122,7 +122,7 @@ export default class GUI {
 		this.$title.addEventListener( 'click', () => this.openAnimated( this._closed ) );
 		this.$title.addEventListener( 'keydown', e => {
 			if ( e.code === 'Enter' || e.code === 'Space' ) {
-				e.preventDefault();
+				e.stopPropagation();
 				this.$title.click();
 			}
 		} );
@@ -182,10 +182,6 @@ export default class GUI {
 		}
 
 		this._closeFolders = closeFolders;
-
-		// Don't fire global key events while typing in the GUI:
-		this.domElement.addEventListener( 'keydown', e => e.stopPropagation() );
-		this.domElement.addEventListener( 'keyup', e => e.stopPropagation() );
 
 	}
 


### PR DESCRIPTION
`e.stopPropagation()` used to be called for every keyup/down triggered within the GUI's DOM tree. Now that's applied per controller. Should fix #69. 

Folders headers will still "eat" keystrokes if the keystroke is Space or Enter (used for toggling open/close).