### PR TITLE
folders inherit disabled touch styles

### DIFF
--- a/src/GUI.js
+++ b/src/GUI.js
@@ -142,7 +142,9 @@ export default class GUI {
 
 		this.title( title );
 
-		if ( touchStyles ) {
+		this._touchStyles = parent ? parent._touchStyles : touchStyles;
+
+		if ( this._touchStyles ) {
 			this.domElement.classList.add( 'allow-touch-styles' );
 		}
 

--- a/tests/touch-styles.js
+++ b/tests/touch-styles.js
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import GUI from '../dist/lil-gui.esm.min.js';
+
+export default () => {
+
+	let gui = new GUI();
+	assert( gui.domElement.classList.contains( 'allow-touch-styles' ), 'touch styles enabled by default' );
+
+	gui = gui.addFolder();
+	assert( gui.domElement.classList.contains( 'allow-touch-styles' ), 'folders inherit touch styles' );
+
+	gui = new GUI( { touchStyles: false } );
+	assert( !gui.domElement.classList.contains( 'allow-touch-styles' ), 'touch styles can be disabled' );
+
+	gui = gui.addFolder();
+	assert( !gui.domElement.classList.contains( 'allow-touch-styles' ), 'folders inherit disabled touch styles' );
+
+};

--- a/tests/utils/shim.js
+++ b/tests/utils/shim.js
@@ -35,7 +35,13 @@ class EventTarget {
 class Element extends EventTarget {
 	constructor() {
 		super();
-		this.classList = { add() {}, remove() {}, toggle() {} };
+		const classes = new Set();
+		this.classList = {
+			add: c => classes.add( c ),
+			contains: c => classes.has( c ),
+			remove() {},
+			toggle() {}
+		};
 		this.style = { setProperty() {} };
 		this.parentElement = { removeChild() {} };
 	}

--- a/tests/utils/shim.js
+++ b/tests/utils/shim.js
@@ -39,7 +39,6 @@ class Element extends EventTarget {
 		this.classList = {
 			add: c => classes.add( c ),
 			contains: c => classes.has( c ),
-			remove() {},
 			toggle() {}
 		};
 		this.style = { setProperty() {} };


### PR DESCRIPTION
Folders inside GUI's with `touchStyles: false` were still allowing touch styles. Fixes #102. 