### PR TITLE
Update TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "rollup": "^1.17.0",
         "sass": "^1.22.10",
         "terser": "^4.3.8",
-        "typescript": "~4.5.5",
+        "typescript": "~5.1.3",
         "webfont": "^11.2.26"
       }
     },
@@ -235,9 +235,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.2.tgz",
-      "integrity": "sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -5613,16 +5613,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -6236,9 +6236,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.2.tgz",
-      "integrity": "sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -10302,9 +10302,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "rollup": "^1.17.0",
     "sass": "^1.22.10",
     "terser": "^4.3.8",
-    "typescript": "~4.5.5",
+    "typescript": "~5.1.3",
     "webfont": "^11.2.26"
   },
   "eslintIgnore": [


### PR DESCRIPTION
Looks like https://github.com/georgealways/lil-gui/issues/93 was fixed by https://github.com/microsoft/TypeScript/pull/54062, so we can update TypeScript freely again now.