### PR TITLE
add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "main": "dist/lil-gui.umd.js",
   "types": "dist/lil-gui.esm.d.ts",
   "sideEffects": false,
+  "exports": {
+    "import": "./dist/lil-gui.esm.js",
+    "require": "./dist/lil-gui.umd.js"
+  },
   "config": {
     "style": "dist/lil-gui.css",
     "styleMin": "dist/lil-gui.min.css"


### PR DESCRIPTION
Add "exports" property to correctly import lil-gui in client / server dual environments like next.js