### PR TITLE
Improve TypeScript types

### DIFF
--- a/src/BooleanController.js
+++ b/src/BooleanController.js
@@ -1,7 +1,17 @@
 import Controller from './Controller';
 
+/**
+ * @template [T=Record<string, unknown>]
+ * @template {keyof T} [K=keyof T]
+ * @extends {Controller<T, K>}
+ */
 export default class BooleanController extends Controller {
 
+	/**
+	 * @param {GUI} parent
+	 * @param {T} object
+	 * @param {K} property
+	 */
 	constructor( parent, object, property ) {
 
 		super( parent, object, property, 'boolean', 'label' );

--- a/src/ColorController.js
+++ b/src/ColorController.js
@@ -3,8 +3,19 @@ import Controller from './Controller';
 import getColorFormat from './utils/getColorFormat';
 import normalizeColorString from './utils/normalizeColorString';
 
+/**
+ * @template [T=Record<string, unknown>]
+ * @template {keyof T} [K=keyof T]
+ * @extends {Controller<T, K>}
+ */
 export default class ColorController extends Controller {
 
+	/**
+	 * @param {GUI} parent
+	 * @param {T} object
+	 * @param {K} property
+	 * @param {number} rgbScale
+	 */
 	constructor( parent, object, property, rgbScale ) {
 
 		super( parent, object, property, 'color' );
@@ -86,6 +97,9 @@ export default class ColorController extends Controller {
 
 	}
 
+	/**
+	 * @returns {T[K]}
+	 */
 	save() {
 		return this._format.toHexString( this.getValue(), this._rgbScale );
 	}

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -2,9 +2,19 @@
 
 /**
  * Base class for all controllers.
+ *
+ * @template [T=Record<string, unknown>]
+ * @template {keyof T} [K=keyof T]
  */
 export default class Controller {
 
+  /**
+   * @param {GUI} parent
+   * @param {T} object
+   * @param {K} property
+   * @param {string} className
+   * @param {string} widgetTag
+   */
 	constructor( parent, object, property, className, widgetTag = 'div' ) {
 
 		/**
@@ -15,13 +25,13 @@ export default class Controller {
 
 		/**
 		 * The object this controller will modify.
-		 * @type {object}
+		 * @type {T}
 		 */
 		this.object = object;
 
 		/**
 		 * The name of the property to control.
-		 * @type {string}
+		 * @type {K}
 		 */
 		this.property = property;
 
@@ -116,7 +126,7 @@ export default class Controller {
 	 *
 	 * For function controllers, the `onChange` callback will be fired on click, after the function
 	 * executes.
-	 * @param {Function} callback
+	 * @param {(v: T[K]) => void} callback
 	 * @returns {this}
 	 * @example
 	 * const controller = gui.add( object, 'property' );
@@ -130,7 +140,7 @@ export default class Controller {
 		/**
 		 * Used to access the function bound to `onChange` events. Don't modify this value directly.
 		 * Use the `controller.onChange( callback )` method instead.
-		 * @type {Function}
+		 * @type {(v: T[K]) => void}
 		 */
 		this._onChange = callback;
 		return this;
@@ -154,7 +164,7 @@ export default class Controller {
 
 	/**
 	 * Pass a function to be called after this controller has been modified and loses focus.
-	 * @param {Function} callback
+	 * @param {(v: T[K]) => void} callback
 	 * @returns {this}
 	 * @example
 	 * const controller = gui.add( object, 'property' );
@@ -168,7 +178,7 @@ export default class Controller {
 		/**
 		 * Used to access the function bound to `onFinishChange` events. Don't modify this value
 		 * directly. Use the `controller.onFinishChange( callback )` method instead.
-		 * @type {Function}
+		 * @type {(v: T[K]) => void}
 		 */
 		this._onFinishChange = callback;
 		return this;
@@ -391,7 +401,7 @@ export default class Controller {
 
 	/**
 	 * Returns `object[ property ]`.
-	 * @returns {any}
+	 * @returns {T[K]}
 	 */
 	getValue() {
 		return this.object[ this.property ];
@@ -399,7 +409,7 @@ export default class Controller {
 
 	/**
 	 * Sets the value of `object[ property ]`, invokes any `onChange` handlers and updates the display.
-	 * @param {any} value
+	 * @param {T[K]} value
 	 * @returns {this}
 	 */
 	setValue( value ) {

--- a/src/FunctionController.js
+++ b/src/FunctionController.js
@@ -1,7 +1,17 @@
 import Controller from './Controller';
 
+/**
+ * @template [T=Record<string, unknown>]
+ * @template {keyof T} [K=keyof T]
+ * @extends {Controller<T, K>}
+ */
 export default class FunctionController extends Controller {
 
+	/**
+	 * @param {GUI} parent
+	 * @param {T} object
+	 * @param {K} property
+	 */
 	constructor( parent, object, property ) {
 
 		super( parent, object, property, 'function' );

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -192,13 +192,16 @@ export default class GUI {
 	 * gui.add( object, 'number', 0, 100, 1 );
 	 * gui.add( object, 'options', [ 1, 2, 3 ] );
 	 *
-	 * @param {object} object The object the controller will modify.
-	 * @param {string} property Name of the property to control.
-	 * @param {number|object|Array} [$1] Minimum value for number controllers, or the set of
+	 * @template T
+	 * @template {keyof T} K
+	 *
+	 * @param {T} object The object the controller will modify.
+	 * @param {K} property Name of the property to control.
+	 * @param {number|Record<string, T[K]>|ReadonlyArray<T[K]>} [$1] Minimum value for number controllers, or the set of
 	 * selectable values for a dropdown.
 	 * @param {number} [max] Maximum value for number controllers.
 	 * @param {number} [step] Step value for number controllers.
-	 * @returns {Controller}
+	 * @returns {Controller<T, K>}
 	 */
 	add( object, property, $1, max, step ) {
 
@@ -251,11 +254,14 @@ export default class GUI {
 	 * gui.addColor( params, 'rgbColor' );
 	 * gui.addColor( params, 'customRange', 255 );
 	 *
-	 * @param {object} object The object the controller will modify.
-	 * @param {string} property Name of the property to control.
+	 * @template T
+	 * @template {keyof T} K
+	 *
+	 * @param {T} object The object the controller will modify.
+	 * @param {K} property Name of the property to control.
 	 * @param {number} rgbScale Maximum value for a color channel when using an RGB color. You may
 	 * need to set this to 255 if your colors are too bright.
-	 * @returns {Controller}
+	 * @returns {ColorController<T, K>}
 	 */
 	addColor( object, property, rgbScale = 1 ) {
 		return new ColorController( this, object, property, rgbScale );

--- a/src/NumberController.js
+++ b/src/NumberController.js
@@ -1,7 +1,20 @@
 import Controller from './Controller';
 
+/**
+ * @template [T=Record<string, unknown>]
+ * @template {keyof T} [K=keyof T]
+ * @extends {Controller<T, K>}
+ */
 export default class NumberController extends Controller {
 
+	/**
+	 * @param {GUI} parent
+	 * @param {T} object
+	 * @param {K} property
+	 * @param {number} [min]
+	 * @param {number} [max]
+	 * @param {number} [step]
+	 */
 	constructor( parent, object, property, min, max, step ) {
 
 		super( parent, object, property, 'number' );

--- a/src/OptionController.js
+++ b/src/OptionController.js
@@ -1,7 +1,18 @@
 import Controller from './Controller';
 
+/**
+ * @template [T=Record<string, unknown>]
+ * @template {keyof T} [K=keyof T]
+ * @extends {Controller<T, K>}
+ */
 export default class OptionController extends Controller {
 
+	/**
+	 * @param {GUI} parent
+	 * @param {T} object
+	 * @param {K} property
+	 * @param {Record<string, T[K]>|ReadonlyArray<T[K]>} options
+	 */
 	constructor( parent, object, property, options ) {
 
 		super( parent, object, property, 'option' );

--- a/src/StringController.js
+++ b/src/StringController.js
@@ -1,7 +1,17 @@
 import Controller from './Controller';
 
+/**
+ * @template [T=Record<string, unknown>]
+ * @template {keyof T} [K=keyof T]
+ * @extends {Controller<T, K>}
+ */
 export default class StringController extends Controller {
 
+	/**
+	 * @param {GUI} parent
+	 * @param {T} object
+	 * @param {K} property
+	 */
 	constructor( parent, object, property ) {
 
 		super( parent, object, property, 'string' );


### PR DESCRIPTION
There are some short-comings in the types as they currently exist, namely:

1. When using `GUI.add`, there is no type-checking to make sure that `property` is a key of the `object`.
2. When using `GUI.add` with an array or object of options for the third argument, there is no type-checking to make sure the options are assignable to the property's value.
3. There is no type-checking of the callback passed to `Controller.onChange` and also therefore the parameter for the callback that is passed to `Controller.onChange` is not inferred, since `onChange` accepts any function.

I wanted to go and create a draft PR to get some initial feedback since I believe this is treading new territory. Most of the existing JSDoc comments are fairly standardized, these would be the first JSDoc comments that are really targeted toward making the type definitions better. It seems like both linting and API creation don't like this new direction.

Is this something you're open to? Or is there a alternative, preferred way to improving the type definitions?