### PR TITLE
Checkbox toggles when you click the label

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -5,7 +5,7 @@
  */
 export default class Controller {
 
-	constructor( parent, object, property, className, widgetTag = 'div' ) {
+	constructor( parent, object, property, className, elementType = 'div' ) {
 
 		/**
 		 * The GUI that contains this controller.
@@ -49,7 +49,7 @@ export default class Controller {
 		 * The outermost container DOM element for this controller.
 		 * @type {HTMLElement}
 		 */
-		this.domElement = document.createElement( 'div' );
+		this.domElement = document.createElement( elementType );
 		this.domElement.classList.add( 'controller' );
 		this.domElement.classList.add( className );
 
@@ -67,7 +67,7 @@ export default class Controller {
 		 * The DOM element that contains the controller's "widget" (which differs by controller type).
 		 * @type {HTMLElement}
 		 */
-		this.$widget = document.createElement( widgetTag );
+		this.$widget = document.createElement( 'div' );
 		this.$widget.classList.add( 'widget' );
 
 		/**

--- a/style/controllers.scss
+++ b/style/controllers.scss
@@ -37,7 +37,7 @@
 		color: var(--string-color);
 	}
 
-	.controller.boolean .widget {
+	.controller.boolean {
 		cursor: pointer;
 	}
 


### PR DESCRIPTION
Revisiting #49 and #50. The fifth argument to the Controller constructor now changes the DOM element type for the entire controller, not the widget container (which is now always a div). The entire controller can be `label` now and we have the intended behavior.