### PR TITLE
replace assert.CallTracker in unit tests

### DIFF
--- a/tests/controller-load.js
+++ b/tests/controller-load.js
@@ -13,32 +13,32 @@ export default () => {
 		const tracker = new CallTracker();
 		const ctrl = gui.add( { x: 0 }, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( 90 ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.calls, 1 );
+		assert.strictEqual( tracker.numCalls, 1 );
 	}
 	{
 		const tracker = new CallTracker();
 		const ctrl = gui.add( { x: false }, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( true ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.calls, 1 );
+		assert.strictEqual( tracker.numCalls, 1 );
 	}
 	{
 		const tracker = new CallTracker();
 		const ctrl = gui.add( { x: 'foo' }, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.calls, 1 );
+		assert.strictEqual( tracker.numCalls, 1 );
 	}
 	{
 		const tracker = new CallTracker();
 		const ctrl = gui.add( { x: 'foo' }, 'x', [ 'bar', 'baz' ] ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.calls, 1 );
+		assert.strictEqual( tracker.numCalls, 1 );
 	}
 	{
 		const tracker = new CallTracker();
 		const obj = { x: [ 0, 1, 0 ] };
 		const ctrl = gui.addColor( obj, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( '#ff00ff' ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.calls, 1 );
+		assert.strictEqual( tracker.numCalls, 1 );
 	}
 
 };

--- a/tests/controller-load.js
+++ b/tests/controller-load.js
@@ -1,36 +1,44 @@
 import assert from 'assert';
 import GUI from '../dist/lil-gui.esm.min.js';
 
+import CallTracker from './utils/CallTracker.js';
+
 export default () => {
 
 	// make sure load calls onFinishChange and returns self
 
 	const gui = new GUI();
 
-	const tracker = new assert.CallTracker();
-
 	{
-		const ctrl = gui.add( { x: 0 }, 'x' ).onFinishChange( tracker.calls( 1 ) );
+		const tracker = new CallTracker();
+		const ctrl = gui.add( { x: 0 }, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( 90 ), ctrl, 'load returns this' );
+		assert.strictEqual( tracker.calls, 1 );
 	}
 	{
-		const ctrl = gui.add( { x: false }, 'x' ).onFinishChange( tracker.calls( 1 ) );
+		const tracker = new CallTracker();
+		const ctrl = gui.add( { x: false }, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( true ), ctrl, 'load returns this' );
+		assert.strictEqual( tracker.calls, 1 );
 	}
 	{
-		const ctrl = gui.add( { x: 'foo' }, 'x' ).onFinishChange( tracker.calls( 1 ) );
+		const tracker = new CallTracker();
+		const ctrl = gui.add( { x: 'foo' }, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
+		assert.strictEqual( tracker.calls, 1 );
 	}
 	{
-		const ctrl = gui.add( { x: 'foo' }, 'x', [ 'bar', 'baz' ] ).onFinishChange( tracker.calls( 1 ) );
+		const tracker = new CallTracker();
+		const ctrl = gui.add( { x: 'foo' }, 'x', [ 'bar', 'baz' ] ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
+		assert.strictEqual( tracker.calls, 1 );
 	}
 	{
+		const tracker = new CallTracker();
 		const obj = { x: [ 0, 1, 0 ] };
-		const ctrl = gui.addColor( obj, 'x' ).onFinishChange( tracker.calls( 1 ) );
+		const ctrl = gui.addColor( obj, 'x' ).onFinishChange( tracker.handler );
 		assert.strictEqual( ctrl.load( '#ff00ff' ), ctrl, 'load returns this' );
+		assert.strictEqual( tracker.calls, 1 );
 	}
-
-	tracker.verify();
 
 };

--- a/tests/controller-load.js
+++ b/tests/controller-load.js
@@ -9,36 +9,32 @@ export default () => {
 
 	const gui = new GUI();
 
-	{
-		const tracker = new CallTracker();
-		const ctrl = gui.add( { x: 0 }, 'x' ).onFinishChange( tracker.handler );
-		assert.strictEqual( ctrl.load( 90 ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.numCalls, 1 );
-	}
-	{
-		const tracker = new CallTracker();
-		const ctrl = gui.add( { x: false }, 'x' ).onFinishChange( tracker.handler );
-		assert.strictEqual( ctrl.load( true ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.numCalls, 1 );
-	}
-	{
-		const tracker = new CallTracker();
-		const ctrl = gui.add( { x: 'foo' }, 'x' ).onFinishChange( tracker.handler );
-		assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.numCalls, 1 );
-	}
-	{
-		const tracker = new CallTracker();
-		const ctrl = gui.add( { x: 'foo' }, 'x', [ 'bar', 'baz' ] ).onFinishChange( tracker.handler );
-		assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.numCalls, 1 );
-	}
-	{
-		const tracker = new CallTracker();
-		const obj = { x: [ 0, 1, 0 ] };
-		const ctrl = gui.addColor( obj, 'x' ).onFinishChange( tracker.handler );
-		assert.strictEqual( ctrl.load( '#ff00ff' ), ctrl, 'load returns this' );
-		assert.strictEqual( tracker.numCalls, 1 );
-	}
+	let tracker, ctrl;
+
+	tracker = new CallTracker();
+	ctrl = gui.add( { x: 0 }, 'x' ).onFinishChange( tracker.handler );
+	assert.strictEqual( ctrl.load( 90 ), ctrl, 'load returns this' );
+	assert.strictEqual( tracker.numCalls, 1 );
+
+	tracker = new CallTracker();
+	ctrl = gui.add( { x: false }, 'x' ).onFinishChange( tracker.handler );
+	assert.strictEqual( ctrl.load( true ), ctrl, 'load returns this' );
+	assert.strictEqual( tracker.numCalls, 1 );
+
+	tracker = new CallTracker();
+	ctrl = gui.add( { x: 'foo' }, 'x' ).onFinishChange( tracker.handler );
+	assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
+	assert.strictEqual( tracker.numCalls, 1 );
+
+	tracker = new CallTracker();
+	ctrl = gui.add( { x: 'foo' }, 'x', [ 'bar', 'baz' ] ).onFinishChange( tracker.handler );
+	assert.strictEqual( ctrl.load( 'bar' ), ctrl, 'load returns this' );
+	assert.strictEqual( tracker.numCalls, 1 );
+
+	tracker = new CallTracker();
+	const obj = { x: [ 0, 1, 0 ] };
+	ctrl = gui.addColor( obj, 'x' ).onFinishChange( tracker.handler );
+	assert.strictEqual( ctrl.load( '#ff00ff' ), ctrl, 'load returns this' );
+	assert.strictEqual( tracker.numCalls, 1 );
 
 };

--- a/tests/number-finish-change.js
+++ b/tests/number-finish-change.js
@@ -58,6 +58,6 @@ export default () => {
 	// todo: the final onFinishChange would be wheel on slider, but that involves a 400ms timeout
 
 	// 3 simulateDrags + the `$input` based update.
-	assert.strictEqual( tracker.calls, 4 );
+	assert.strictEqual( tracker.numCalls, 4 );
 
 };

--- a/tests/number-finish-change.js
+++ b/tests/number-finish-change.js
@@ -11,11 +11,7 @@ export default () => {
 	const obj = { x: 0 };
 	const ctrl = gui.add( obj, 'x', 0, 1000 );
 
-	let _args, _this;
-	let tracker = new CallTracker( function( ...args ) {
-		_this = this;
-		_args = args;
-	} );
+	const tracker = new CallTracker();
 
 	ctrl.onFinishChange( tracker.handler );
 	assert.strictEqual( ctrl._onFinishChange, tracker.handler, 'Number.onFinishChange: sets _onFinishChange' );
@@ -26,8 +22,8 @@ export default () => {
 	prefix = 'number finish change (mouse, drag slider)';
 
 	simulateDrag( 'mouse', ctrl.$slider, { dx: 20 } );
-	assert.strictEqual( _this, ctrl, `${prefix}: this is bound to controller in handler` );
-	assert.deepEqual( _args, [ obj.x ], `${prefix}: new value is the first and only argument` );
+	assert.strictEqual( tracker.lastThis, ctrl, `${prefix}: this is bound to controller in handler` );
+	assert.deepEqual( tracker.lastArgs, [ obj.x ], `${prefix}: new value is the first and only argument` );
 
 	// todo: nit picky, but tapping in the same place on the slider shouldn't trigger onFinishChange
 
@@ -35,15 +31,15 @@ export default () => {
 	prefix = 'number finish change (touch, drag slider)';
 
 	simulateDrag( 'touch', ctrl.$slider, { dx: -30 } );
-	assert.strictEqual( _this, ctrl, `${prefix}: this is bound to controller in handler` );
-	assert.deepEqual( _args, [ obj.x ], `${prefix}: new value is the first and only argument` );
+	assert.strictEqual( tracker.lastThis, ctrl, `${prefix}: this is bound to controller in handler` );
+	assert.deepEqual( tracker.lastArgs, [ obj.x ], `${prefix}: new value is the first and only argument` );
 
 	// onFinishChange 3
 	prefix = 'number finish change (mouse, drag input)';
 
 	simulateDrag( 'mouse', ctrl.$input, { dy: 20 } );
-	assert.strictEqual( _this, ctrl, `${prefix}: this is bound to controller in handler` );
-	assert.deepEqual( _args, [ obj.x ], `${prefix}: new value is the first and only argument` );
+	assert.strictEqual( tracker.lastThis, ctrl, `${prefix}: this is bound to controller in handler` );
+	assert.deepEqual( tracker.lastArgs, [ obj.x ], `${prefix}: new value is the first and only argument` );
 
 	// onFinishChange 4: blur input
 	prefix = 'number finish change (blur input)';
@@ -52,8 +48,8 @@ export default () => {
 	ctrl.$input.$callEventListener( 'input' );
 	ctrl.$input.blur();
 
-	assert.strictEqual( _this, ctrl, `${prefix}: this is bound to controller in handler` );
-	assert.deepEqual( _args, [ 666 ], `${prefix}: new value is the first and only argument` );
+	assert.strictEqual( tracker.lastThis, ctrl, `${prefix}: this is bound to controller in handler` );
+	assert.deepEqual( tracker.lastArgs, [ 666 ], `${prefix}: new value is the first and only argument` );
 
 	// blurs without changes don't call onFinishChange
 	ctrl.$input.focus();

--- a/tests/number-finish-change.js
+++ b/tests/number-finish-change.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import GUI from '../dist/lil-gui.esm.min.js';
 
 import simulateDrag from './utils/simulateDrag.js';
+import CallTracker from './utils/CallTracker.js';
 
 export default () => {
 
@@ -10,17 +11,14 @@ export default () => {
 	const obj = { x: 0 };
 	const ctrl = gui.add( obj, 'x', 0, 1000 );
 
-	let tracker = new assert.CallTracker();
-
-	let handler, _args, _this;
-
-	handler = tracker.calls( function( ...args ) {
+	let _args, _this;
+	let tracker = new CallTracker( function( ...args ) {
 		_this = this;
 		_args = args;
-	}, 4 ); // expecting this many onFinishChange
+	} );
 
-	ctrl.onFinishChange( handler );
-	assert.strictEqual( ctrl._onFinishChange, handler, 'Number.onFinishChange: sets _onFinishChange' );
+	ctrl.onFinishChange( tracker.handler );
+	assert.strictEqual( ctrl._onFinishChange, tracker.handler, 'Number.onFinishChange: sets _onFinishChange' );
 
 	let prefix;
 
@@ -63,6 +61,7 @@ export default () => {
 
 	// todo: the final onFinishChange would be wheel on slider, but that involves a 400ms timeout
 
-	tracker.verify();
+	// 3 simulateDrags + the `$input` based update.
+	assert.strictEqual( tracker.calls, 4 );
 
 };

--- a/tests/on-change-controller.js
+++ b/tests/on-change-controller.js
@@ -1,41 +1,40 @@
 import assert from 'assert';
 import GUI from '../dist/lil-gui.esm.min.js';
 
+import CallTracker from './utils/CallTracker.js';
+
 export default () => {
 
 	const gui = new GUI();
 
 	const controller = gui.add( { x: 0 }, 'x' );
 
-	let tracker = new assert.CallTracker();
+	let _args, _this;
 
-	let handler, _args, _this;
-
-	handler = tracker.calls( function( ...args ) {
+	let tracker = new CallTracker( function( ...args ) {
 		_this = this;
 		_args = args;
-	}, 1 );
+	} );
 
-	controller.onChange( handler );
+	controller.onChange( tracker.handler );
 
 	const value = 9;
 	controller.setValue( value );
 
-	assert.strictEqual( controller._onChange, handler, 'onChange: sets _onChange' );
+	assert.strictEqual( controller._onChange, tracker.handler, 'onChange: sets _onChange' );
 	assert.strictEqual( _this, controller, 'onChange: this is bound to controller in handler' );
 	assert.deepEqual( _args, [ value ], 'onChange: new value is the first and only argument' );
 
-	tracker.verify();
+	assert.strictEqual( tracker.calls, 1 );
 
 	// function controller should call onChange after click
 
-	tracker = new assert.CallTracker();
-	handler = tracker.calls( () => {}, 1 );
+	tracker = new CallTracker();
 
 	const functionController = gui.add( { fnc() {} }, 'fnc' );
-	functionController.onChange( handler );
+	functionController.onChange( tracker.handler );
 	functionController.$button.$callEventListener( 'click' );
 
-	tracker.verify();
+	assert.strictEqual( tracker.calls, 1 );
 
 };

--- a/tests/on-change-controller.js
+++ b/tests/on-change-controller.js
@@ -9,12 +9,7 @@ export default () => {
 
 	const controller = gui.add( { x: 0 }, 'x' );
 
-	let _args, _this;
-
-	let tracker = new CallTracker( function( ...args ) {
-		_this = this;
-		_args = args;
-	} );
+	let tracker = new CallTracker();
 
 	controller.onChange( tracker.handler );
 
@@ -22,8 +17,8 @@ export default () => {
 	controller.setValue( value );
 
 	assert.strictEqual( controller._onChange, tracker.handler, 'onChange: sets _onChange' );
-	assert.strictEqual( _this, controller, 'onChange: this is bound to controller in handler' );
-	assert.deepEqual( _args, [ value ], 'onChange: new value is the first and only argument' );
+	assert.strictEqual( tracker.lastThis, controller, 'onChange: this is bound to controller in handler' );
+	assert.deepEqual( tracker.lastArgs, [ value ], 'onChange: new value is the first and only argument' );
 
 	assert.strictEqual( tracker.calls, 1 );
 

--- a/tests/on-change-controller.js
+++ b/tests/on-change-controller.js
@@ -20,7 +20,7 @@ export default () => {
 	assert.strictEqual( tracker.lastThis, controller, 'onChange: this is bound to controller in handler' );
 	assert.deepEqual( tracker.lastArgs, [ value ], 'onChange: new value is the first and only argument' );
 
-	assert.strictEqual( tracker.calls, 1 );
+	assert.strictEqual( tracker.numCalls, 1 );
 
 	// function controller should call onChange after click
 
@@ -30,6 +30,6 @@ export default () => {
 	functionController.onChange( tracker.handler );
 	functionController.$button.$callEventListener( 'click' );
 
-	assert.strictEqual( tracker.calls, 1 );
+	assert.strictEqual( tracker.numCalls, 1 );
 
 };

--- a/tests/on-change-gui.js
+++ b/tests/on-change-gui.js
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import GUI from '../dist/lil-gui.esm.min.js';
 
+import CallTracker from './utils/CallTracker.js';
+
 export default () => {
 
 	const gui = new GUI();
@@ -11,19 +13,15 @@ export default () => {
 	const object2 = { y: 0 };
 	const nested = gui.addFolder( '' ).add( object2, 'y' );
 
-	let tracker = new assert.CallTracker();
+	let tracker = new CallTracker();
 
-	let handler, _args;
-
-	handler = tracker.calls( ( ...args ) => _args = args );
-
-	gui.onChange( handler );
+	gui.onChange( tracker.handler );
 
 	let value = 1;
 
 	controller.setValue( value );
-	assert.strictEqual( gui._onChange, handler, 'sets _onChange' );
-	assert.deepStrictEqual( _args, [ {
+	assert.strictEqual( gui._onChange, tracker.handler, 'sets _onChange' );
+	assert.deepStrictEqual( tracker.lastArgs, [ {
 		object: object1,
 		property: 'x',
 		controller,
@@ -33,7 +31,7 @@ export default () => {
 	value = 2;
 
 	nested.setValue( value );
-	assert.deepStrictEqual( _args, [ {
+	assert.deepStrictEqual( tracker.lastArgs, [ {
 		object: object2,
 		property: 'y',
 		controller: nested,

--- a/tests/on-open-close.js
+++ b/tests/on-open-close.js
@@ -25,7 +25,7 @@ export default () => {
 	// ignore redundant calls
 	folder2.close();
 
-	assert.deepEqual( tracker.calls, 2 );
+	assert.deepEqual( tracker.numCalls, 2 );
 
 };
 

--- a/tests/on-open-close.js
+++ b/tests/on-open-close.js
@@ -1,36 +1,31 @@
 import assert from 'assert';
 import GUI from '../dist/lil-gui.esm.min.js';
 
+import CallTracker from './utils/CallTracker.js';
+
 export default () => {
 
-	const tracker = new assert.CallTracker();
-
-	let _args, _this;
-
-	const rootHandler = tracker.calls( function( ...args ) {
-		_args = args;
-		_this = this;
-	}, 2 );
+	const tracker = new CallTracker();
 
 	const root = new GUI();
 
 	const folder1 = root.addFolder();
 	const folder2 = root.addFolder();
 
-	root.onOpenClose( rootHandler );
+	root.onOpenClose( tracker.handler );
 
 	folder1.close();
-	assert.strictEqual( _args[ 0 ], folder1 );
-	assert.strictEqual( _this, root );
+	assert.strictEqual( tracker.lastArgs[ 0 ], folder1 );
+	assert.strictEqual( tracker.lastThis, root );
 
 	folder2.close();
-	assert.strictEqual( _args[ 0 ], folder2 );
-	assert.strictEqual( _this, root );
+	assert.strictEqual( tracker.lastArgs[ 0 ], folder2 );
+	assert.strictEqual( tracker.lastThis, root );
 
 	// ignore redundant calls
 	folder2.close();
 
-	tracker.verify();
+	assert.deepEqual( tracker.calls, 2 );
 
 };
 

--- a/tests/reset-finish-change.js
+++ b/tests/reset-finish-change.js
@@ -1,19 +1,20 @@
 import assert from 'assert';
 import GUI from '../dist/lil-gui.esm.min.js';
 
+import CallTracker from './utils/CallTracker.js';
+
 export default () => {
 
 	const gui = new GUI();
 
-	const tracker = new assert.CallTracker();
-	const handler = tracker.calls( function(){}, 1 );
+	const tracker = new CallTracker();
 
 	const c = gui.add( { x: 0 }, 'x' );
 
-	c.onFinishChange( handler );
+	c.onFinishChange( tracker.handler );
 
 	c.reset();
 
-	tracker.verify();
+	assert.strictEqual( tracker.calls, 1 );
 
 };

--- a/tests/reset-finish-change.js
+++ b/tests/reset-finish-change.js
@@ -15,6 +15,6 @@ export default () => {
 
 	c.reset();
 
-	assert.strictEqual( tracker.calls, 1 );
+	assert.strictEqual( tracker.numCalls, 1 );
 
 };

--- a/tests/utils/CallTracker.js
+++ b/tests/utils/CallTracker.js
@@ -1,0 +1,16 @@
+export default class CallTracker {
+
+	constructor( handler ) {
+
+		this.calls = 0;
+
+		const _this = this;
+
+		this.handler = function() {
+			_this.calls++;
+			handler && handler.call( this, ...arguments );
+		};
+
+	}
+
+}

--- a/tests/utils/CallTracker.js
+++ b/tests/utils/CallTracker.js
@@ -4,14 +4,14 @@ export default class CallTracker {
 
 	constructor( handler ) {
 
-		this.calls = 0;
+		this.numCalls = 0;
 		this.lastThis = undefined;
 		this.lastArgs = undefined;
 
 		const _this = this;
 
 		this.handler = function( ...args ) {
-			_this.calls++;
+			_this.numCalls++;
 			_this.lastThis = this;
 			_this.lastArgs = args;
 			handler && handler.call( this, ...args );

--- a/tests/utils/CallTracker.js
+++ b/tests/utils/CallTracker.js
@@ -1,14 +1,20 @@
+// replaces the deprecated assert.CallTracker
+// node suggests the "mock helper function" instead, but it feels overkill
 export default class CallTracker {
 
 	constructor( handler ) {
 
 		this.calls = 0;
+		this.lastThis = undefined;
+		this.lastArgs = undefined;
 
 		const _this = this;
 
-		this.handler = function() {
+		this.handler = function( ...args ) {
 			_this.calls++;
-			handler && handler.call( this, ...arguments );
+			_this.lastThis = this;
+			_this.lastArgs = args;
+			handler && handler.call( this, ...args );
 		};
 
 	}


### PR DESCRIPTION
replaces the deprecated assert.CallTracker in unit tests