### PR TITLE
pass previous value to controller.onChange

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -405,7 +405,7 @@ export default class Controller {
 		const previousValue = this.getValue();
 		if (value !== previousValue) {
 			this.object[ this.property ] = value;
-			this._callOnChange();
+			this._callOnChange(value, previousValue);
 			this.updateDisplay();
 		}
 		return this;

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -140,12 +140,12 @@ export default class Controller {
 	 * Calls the onChange methods of this controller and its parent GUI.
 	 * @protected
 	 */
-	_callOnChange() {
+	_callOnChange(value, previousValue) {
 
 		this.parent._callOnChange( this );
 
 		if ( this._onChange !== undefined ) {
-			this._onChange.call( this, this.getValue() );
+			this._onChange.call( this, value, previousValue );
 		}
 
 		this._changed = true;
@@ -401,10 +401,13 @@ export default class Controller {
 	 * @param {any} value
 	 * @returns {this}
 	 */
-	setValue( value ) {
-		this.object[ this.property ] = value;
-		this._callOnChange();
-		this.updateDisplay();
+	setValue(value) {
+		const previousValue = this.getValue();
+		if (value !== previousValue) {
+			this.object[ this.property ] = value;
+			this._callOnChange();
+			this.updateDisplay();
+		}
 		return this;
 	}
 


### PR DESCRIPTION
This PR adds the ability to retrieve the previous value in the `onChange` callback, it's a must have in any watcher system and allows side effects based on the update. 

It also remove useless updates caused by the click event and only call `onChange` if the value really changed.

This PR is a bit quick so it would be nice to point me in the correct direction to also updates any typing/doc/comment to make the PR receivable.

---
```js
gui
  .add(settings, 'count')
  .name('Count')
  .onChange((count, previous_count) => {
    handle(count)
	if(count > previous_count) console.log('bigger count!')
  })
```