### PR TITLE
Prevent name() and title() from rendering HTML tags

### DIFF
--- a/examples/kitchen-sink/customization.js
+++ b/examples/kitchen-sink/customization.js
@@ -97,18 +97,18 @@ function updateStylesheet() {
 	}
 	if ( style ) {
 		style = '.lil-gui {\n' + style + '}';
-		customDisplay.innerHTML = style;
-		customStyleTag.innerHTML = style;
+		customDisplay.textContent = style;
+		customStyleTag.textContent = style;
 	} else {
-		customDisplay.innerHTML = '';
-		customStyleTag.innerHTML = '';
+		customDisplay.textContent = '';
+		customStyleTag.textContent = '';
 	}
 }
 
 const defaultStyleTag = Array.from( document.querySelectorAll( 'style' ) )
-	.find( tag => tag.innerHTML.includes( 'lil-gui' ) );
+	.find( tag => tag.textContent.includes( 'lil-gui' ) );
 
-defaultStyleTag.innerHTML.replace( /(--[a-z0-9-]+)\s*:\s*([^;}]*)[;}]/ig, ( _, property, value ) => {
+defaultStyleTag.textContent.replace( /(--[a-z0-9-]+)\s*:\s*([^;}]*)[;}]/ig, ( _, property, value ) => {
 
 	if ( property in stylesheet ) return;
 

--- a/homepage/guide-examples.js
+++ b/homepage/guide-examples.js
@@ -215,7 +215,7 @@ function findChildAfter( element, re ) {
 }
 
 function replaceContents( element, text ) {
-	element.innerHTML = text;
+	element.textContent = text;
 	element.classList.add( 'changed' );
 	clearTimeout( element.timeout );
 	element.timeout = setTimeout( () => {

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -105,7 +105,7 @@ export default class Controller {
 		 * @type {string}
 		 */
 		this._name = name;
-		this.$name.innerHTML = name;
+		this.$name.textContent = name;
 		return this;
 	}
 

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -486,7 +486,7 @@ export default class GUI {
 		 * @type {string}
 		 */
 		this._title = title;
-		this.$title.innerHTML = title;
+		this.$title.textContent = title;
 		return this;
 	}
 

--- a/src/OptionController.js
+++ b/src/OptionController.js
@@ -43,7 +43,7 @@ export default class OptionController extends Controller {
 
 		this._names.forEach( name => {
 			const $option = document.createElement( 'option' );
-			$option.innerHTML = name;
+			$option.textContent = name;
 			this.$select.appendChild( $option );
 		} );
 
@@ -57,7 +57,7 @@ export default class OptionController extends Controller {
 		const value = this.getValue();
 		const index = this._values.indexOf( value );
 		this.$select.selectedIndex = index;
-		this.$display.innerHTML = index === -1 ? value : this._names[ index ];
+		this.$display.textContent = index === -1 ? value : this._names[ index ];
 		return this;
 	}
 

--- a/src/utils/injectStyles.js
+++ b/src/utils/injectStyles.js
@@ -1,6 +1,6 @@
 export default function( cssContent ) {
 	const injected = document.createElement( 'style' );
-	injected.innerHTML = cssContent;
+	injected.textContent = cssContent;
 	const before = document.querySelector( 'head link[rel=stylesheet], head style' );
 	if ( before ) {
 		document.head.insertBefore( injected, before );


### PR DESCRIPTION
## Description

The methods such as `.title()` and `.name()` internally use the `element.innerHTML` interface for text creation. This implementation causes inputs like `<input>` to be interpreted as an <input> element, rather than plain text.

```javascript
gui.add( object, '<input>' ); // The key name of the controller is an <input> element
```

The proposed solution is to use the `element.textContent` interface instead.

## Other

I have noticed that in `/tests/basic.js`, the `assert.strictEqual` function call employs `innerHTML`, as follows:

```javascript
assert.strictEqual( controller4.$name.innerHTML, name, 'name sets innerHTML' );
```

I am unsure of the purpose behind the use of `innerHTML` in this instance, so I have not modified this script. Please could you check and resolve this issue?

 Thank you for your efforts.